### PR TITLE
fix: skip re-install when package already installed on node

### DIFF
--- a/src/components/manifest/ManifestProcessor.tsx
+++ b/src/components/manifest/ManifestProcessor.tsx
@@ -118,9 +118,8 @@ export function ManifestProcessor({ onComplete, onBack }: ManifestProcessorProps
 
       try {
         if (packageName) {
-          // Check node first: if the app is already installed (e.g. dev mode),
-          // skip the registry entirely and go straight to completion.
-          const DEV_SIGNER_ID = 'did:key:z6MknF3p5L5FDHJQ7FREUapuX4Wmp4MtF6WrHYaXS2B3eZQd';
+          // Check node first: if the app is already installed, skip the
+          // registry entirely and go straight to completion.
           let installedLocally = false;
           try {
             const token = getAccessToken();
@@ -132,7 +131,7 @@ export function ManifestProcessor({ onComplete, onBack }: ManifestProcessorProps
                 const appsJson = await appsRes.json();
                 const apps = appsJson?.data?.apps || [];
                 for (const app of apps) {
-                  if (app.package === packageName && app.signer_id === DEV_SIGNER_ID) {
+                  if (app.package === packageName) {
                     installedLocally = true;
                     setAlreadyInstalled(true);
                     setExistingAppId(app.id);


### PR DESCRIPTION
## Summary

- Every login was triggering a full app re-install from the registry
- Root cause: `ManifestProcessor.tsx` checked `app.package === packageName && app.signer_id === DEV_SIGNER_ID` to decide if the app is already installed
- The hardcoded `DEV_SIGNER_ID` never matched on production nodes (or any node where the app was installed via registry/normal flow), so `installedLocally` stayed `false` and it always fell through to re-install
- Fix: check `app.package === packageName` only — if the package name matches, the app is installed regardless of who signed it

## Test plan

- [ ] Log in to an app that uses `package-name` (e.g. curb) — confirm it does **not** re-install on each login
- [ ] First-time install (app not on node) still works — falls through to registry/install flow as before
- [ ] Dev workflow unaffected — dev-installed apps are still detected by package name

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-condition change in install short-circuit logic; no auth or data model changes.
> 
> **Overview**
> **`ManifestProcessor`** now treats an app as already installed on the node when **`app.package`** matches the requested package name, without requiring a specific **`signer_id`**.
> 
> Previously, local detection only succeeded when the installed app matched a hardcoded dev signer DID, so production/registry installs were missed and each login could re-fetch from the registry and re-install. Matching by package name alone skips the registry and completes immediately when the package is already present, regardless of who signed it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab8f951109a34934665d0d9bc78bbfca71a87c26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->