### PR TITLE
fix: make ErrorView retry button text black for readability

### DIFF
--- a/src/components/common/ErrorView.tsx
+++ b/src/components/common/ErrorView.tsx
@@ -66,7 +66,7 @@ export function ErrorView({ message, onRetry, buttonText }: ErrorViewProps) {
                 onClick={handleAction}
                 style={{
                   borderColor: 'var(--color-border-brand)',
-                  color: 'var(--color-text-brand)',
+                  color: '#000000',
                 }}
               >
                 {buttonText || 'Try Again'}


### PR DESCRIPTION
## Problem

The error popup (e.g. "Something went wrong — No versions found for package...") had a retry/reload button with green text (`--color-text-brand`, `#A5FF11`) on the green primary button background — green-on-green, effectively invisible.

## Fix

Changed the button text color to black in the shared `ErrorView` component, which fixes contrast everywhere the component is used (Retry, Reload Page, Try Again, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single inline style change in a shared error UI component with no auth, data, or API impact.
> 
> **Overview**
> Fixes **unreadable retry/action labels** on the shared `ErrorView` primary button by changing inline button text color from brand green (`--color-text-brand`) to **black** (`#000000`).
> 
> Because `ErrorView` is reused for error states (e.g. auth retry, install errors), every “Try Again” / retry-style action on that green primary button gets proper contrast without per-caller overrides.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6aa585a8b7261f5cf5aa039a279cbb9c3b9d1cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->