### PR TITLE
fix(manifest): fall back to node-installed app when registry is unreachable

### DIFF
--- a/src/components/manifest/ManifestProcessor.tsx
+++ b/src/components/manifest/ManifestProcessor.tsx
@@ -118,10 +118,12 @@ export function ManifestProcessor({ onComplete, onBack }: ManifestProcessorProps
 
       try {
         if (packageName) {
-          // Check node first: if the app is already installed (e.g. dev mode),
-          // skip the registry entirely and go straight to completion.
+          // Check the node first: if the app is already installed we can skip the
+          // registry entirely. We grab the node's app list once and reuse it both
+          // for the dev fast-path and as a fallback when the registry is
+          // unreachable (offline / CSP-blocked / LAN node with no outbound).
           const DEV_SIGNER_ID = 'did:key:z6MknF3p5L5FDHJQ7FREUapuX4Wmp4MtF6WrHYaXS2B3eZQd';
-          let installedLocally = false;
+          let nodeApps: any[] = [];
           try {
             const token = getAccessToken();
             if (token) {
@@ -130,34 +132,42 @@ export function ManifestProcessor({ onComplete, onBack }: ManifestProcessorProps
               });
               if (appsRes.ok) {
                 const appsJson = await appsRes.json();
-                const apps = appsJson?.data?.apps || [];
-                for (const app of apps) {
-                  if (app.package === packageName && app.signer_id === DEV_SIGNER_ID) {
-                    installedLocally = true;
-                    setAlreadyInstalled(true);
-                    setExistingAppId(app.id);
-                    localStorage.setItem('installed-application-id', app.id);
-                    localStorage.setItem('manifest-info', JSON.stringify({
-                      id: packageName,
-                      name: packageName,
-                      version: app.version || '0.0.0',
-                    }));
-                    setLoading(false);
-                    if (!completionInProgressRef.current) {
-                      completionInProgressRef.current = true;
-                      onCompleteRef.current('', '');
-                      completionInProgressRef.current = false;
-                    }
-                    return;
-                  }
-                }
+                nodeApps = appsJson?.data?.apps || [];
               }
             }
           } catch (nodeCheckErr) {
             console.debug('Node app check failed:', nodeCheckErr);
           }
 
-          if (!installedLocally) {
+          // Proceed with an app that's already installed on the node, skipping the
+          // registry round-trip entirely.
+          const completeWithLocalApp = (app: any) => {
+            setAlreadyInstalled(true);
+            setExistingAppId(app.id);
+            localStorage.setItem('installed-application-id', app.id);
+            localStorage.setItem('manifest-info', JSON.stringify({
+              id: packageName,
+              name: packageName,
+              version: app.version || '0.0.0',
+            }));
+            setLoading(false);
+            if (!completionInProgressRef.current) {
+              completionInProgressRef.current = true;
+              onCompleteRef.current('', '');
+              completionInProgressRef.current = false;
+            }
+          };
+
+          // Dev fast-path: a dev-signed build is already on the node.
+          const devApp = nodeApps.find(
+            (app) => app.package === packageName && app.signer_id === DEV_SIGNER_ID,
+          );
+          if (devApp) {
+            completeWithLocalApp(devApp);
+            return;
+          }
+
+          try {
             const client = registryUrl ? new RegistryClient(registryUrl) : registryClient;
             const manifestData = await client.getManifest(packageName, packageVersion || undefined);
             setManifest(manifestData);
@@ -166,6 +176,17 @@ export function ManifestProcessor({ onComplete, onBack }: ManifestProcessorProps
               name: manifestData.name,
               version: manifestData.version,
             }));
+          } catch (registryErr) {
+            // Registry unreachable. Rather than dead-ending the whole login on the
+            // auth page, fall back to the app already installed on the node (under
+            // any signer) if there is one — that's all we need to mint a token.
+            const localApp = nodeApps.find((app) => app.package === packageName);
+            if (localApp) {
+              console.warn('Registry unavailable; using app already installed on node:', registryErr);
+              completeWithLocalApp(localApp);
+              return;
+            }
+            throw registryErr;
           }
         } else if (manifestUrl) {
           const response = await fetch(manifestUrl);


### PR DESCRIPTION
## Problem

First-time login from an app (e.g. MeroPixArt) could **dead-end on the auth page**. `ManifestProcessor` resolves the app's manifest from the registry (`apps.calimero.network`); when that `fetch` doesn't go through — offline, CSP-blocked, or a LAN/localhost node without reliable outbound — it set an error and stopped the entire login flow.

The pre-check meant to skip the registry only matched a **dev-signed** build (`signer_id === DEV_SIGNER_ID`), so an app installed under the user's **own** identity wasn't recognized and was forced down the failing registry path. Going back to the landing page and retrying appeared to "fix" it only because the node-check then short-circuited before the registry call ever happened.

Observed console symptoms on the first attempt:
- `Failed to fetch versions for <package>: TypeError: Failed to fetch`
- `Failed to fetch manifest: TypeError: Failed to fetch`
- (plus a benign, already-handled `Token validation failed: HTTP 401` from stale-token recovery)

The registry itself is healthy (200, `access-control-allow-origin: *`, package published), so the failure is client-side/environmental — which an already-installed app shouldn't depend on.

## Fix

Fetch the node's installed apps once, then:
- keep the existing dev-signed fast-path, and
- if the registry call throws, **fall back to the app already installed on the node (matched by package name)** before erroring — that's all that's needed to mint the scoped token.

The registry-reachable happy path is unchanged (the `catch` only runs on failure).

## Test plan
- `npm run build` (tsc + vite) passes.
- Manual: on a local node with the app already installed, first-time login now completes instead of getting stuck on the auth page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the package login path in `ManifestProcessor`, but only adds a fallback when the registry fails; the successful registry flow is unchanged.
> 
> **Overview**
> **Package login** no longer dead-ends on the auth page when the registry cannot be reached but the app is already on the node.
> 
> `ManifestProcessor` now loads the node’s installed apps **once** and reuses that list for the existing dev-signed skip and a new **registry failure** path. Shared completion logic is centralized in `completeWithLocalApp`. If `getManifest` throws (offline, CSP, LAN without outbound), it completes login using any local install matched by **package name**—not only the dev signer—instead of surfacing an error. The registry-available path is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12ab61b764fc8004f60cd3c0aecff9f1ac2e1c45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->