### PR TITLE
fix(auth): stop scoping client-key permissions to the application id

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,32 @@
+name: Tests
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  unit:
+    name: Unit & contract tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      # No lockfile is committed; mero-icons pins react 18 peer while the
+      # app is on react 19, so plain `npm install` refuses to resolve.
+      - name: Install dependencies
+        run: npm install --legacy-peer-deps --no-audit --no-fund
+
+      - name: Run tests
+        run: npx vitest run
+
+      - name: Build
+        run: npm run build

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.59.1",
+    "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
     "@types/node": "^22.15.18",

--- a/src/__tests__/client-key-permissions.test.tsx
+++ b/src/__tests__/client-key-permissions.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * Contract pin: the permissions the app requests MUST reach
+ * POST /admin/client-key untouched.
+ *
+ * Core's permission model treats bracket params on context permissions as
+ * context ids, and the SDK routes (GET/POST /admin-api/contexts,
+ * POST /jsonrpc) require Global scope. Since core 0.11.0-rc.9 enforces
+ * token scopes, any rewrite of the requested permissions (e.g. scoping them
+ * to the application id, as this flow did until PR #33) mints tokens the
+ * node rejects with 403 on every route — locking apps in an endless
+ * login loop.
+ *
+ * Core-side twin: `core/crates/auth/tests/client_token_contract.rs` asserts
+ * these exact strings satisfy the validator. If you change what this flow
+ * sends, update that contract test in the same breath.
+ */
+
+import React from 'react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../vitest.setup';
+import { PackageFlow } from '../flows/PackageFlow';
+
+// The flow steps before token generation (registry fetch, app install,
+// permission review UI) are not under test — stub them down to their
+// completion callbacks so the test drives PackageFlow's own logic only.
+vi.mock('../components/manifest/ManifestProcessor', () => ({
+  ManifestProcessor: ({ onComplete }: { onComplete: () => void }) => (
+    <button onClick={onComplete}>manifest-complete</button>
+  ),
+}));
+vi.mock('../components/permissions/PermissionsView', () => ({
+  PermissionsView: ({ onComplete }: { onComplete: () => void }) => (
+    <button onClick={onComplete}>approve-permissions</button>
+  ),
+}));
+
+const APP_ID = '9e4gX24aMx3KWWViZeYu8E4e8UrntWDEsuDTFJTXdKsu';
+
+/** What mero-react's getPermissionsForMode(AppMode.MultiContext) sends. */
+const REQUESTED = ['context:create', 'context:list', 'context:execute'];
+
+describe('client-key permission passthrough (rc.9 contract)', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+
+    sessionStorage.setItem('permissions', REQUESTED.join(','));
+    sessionStorage.setItem('callback-url', 'http://app.example.com/');
+    // Set by the (stubbed) manifest/install step in the real flow.
+    localStorage.setItem('installed-application-id', APP_ID);
+  });
+
+  it('sends the requested permissions unscoped, with no context binding', async () => {
+    let requestBody: {
+      context_id: string;
+      context_identity: string;
+      permissions: string[];
+    } | null = null;
+
+    server.use(
+      http.post('*/admin/client-key', async ({ request }) => {
+        requestBody = (await request.json()) as typeof requestBody;
+        return HttpResponse.json({
+          data: { access_token: 'access', refresh_token: 'refresh' },
+        });
+      }),
+    );
+
+    render(<PackageFlow mode="multi-context" packageName="test-app" />);
+
+    await userEvent.click(screen.getByText('manifest-complete'));
+    await userEvent.click(screen.getByText('approve-permissions'));
+    await userEvent.click(await screen.findByText('Generate Token'));
+
+    await vi.waitFor(() => expect(requestBody).not.toBeNull());
+
+    // The exact strings the app demanded — no [<application-id>] rewrite.
+    // (normalizePermissions may reorder; order is irrelevant to core.)
+    expect([...requestBody!.permissions].sort()).toEqual([...REQUESTED].sort());
+    for (const perm of requestBody!.permissions) {
+      expect(perm).not.toContain('[');
+    }
+
+    // Multi-context mints an unbound token: core skips the context[...]
+    // binding when both fields are empty.
+    expect(requestBody!.context_id).toBe('');
+    expect(requestBody!.context_identity).toBe('');
+  });
+});

--- a/src/components/auth/LoginView.tsx
+++ b/src/components/auth/LoginView.tsx
@@ -434,20 +434,14 @@ const LoginView: React.FC = () => {
         permissions = permissionsParam.split(',');
       }
 
-      // Scope permissions to the installed application ID if available
-      const installedAppId = localStorage.getItem('installed-application-id');
-      if (installedAppId) {
-        console.log('Scoping permissions to application:', installedAppId);
-        // Scope context permissions to the specific application
-        permissions = permissions.map(perm => {
-          // Only scope context permissions (context:create, context:list, context:execute)
-          if (perm.startsWith('context:')) {
-            return `${perm}[${installedAppId}]`;
-          }
-          return perm;
-        });
-        console.log('Application-scoped permissions:', permissions);
-      }
+      // Pass the requested permissions through unscoped. Do NOT rewrite them to
+      // `context:*[<application-id>]`: core's permission model treats bracket
+      // params on context permissions as context ids, and its path-based route
+      // mappings require Global scope for `POST /jsonrpc` (context:execute) and
+      // `GET/POST /admin-api/contexts` (context:list / context:create). Since
+      // core 0.11.0-rc.9 enforces token scopes (default-deny on /admin-api/*),
+      // an application-id-scoped token is rejected with 403 on all of those
+      // routes, which locks every app in a redirect-back-to-login loop.
 
       const response = await generateClientKeyDirect({
         context_id: contextId || '',

--- a/src/flows/PackageFlow.tsx
+++ b/src/flows/PackageFlow.tsx
@@ -93,18 +93,16 @@ export const PackageFlow: React.FC<PackageFlowProps> = ({
   const generateAndRedirect = async (contextId: string | null, identity: string | null) => {
     setGenerating(true);
     try {
-      let scopedPermissions = [...permissions];
-
-      if (installedAppId) {
-        scopedPermissions = scopedPermissions.map(perm =>
-          perm.startsWith('context:') ? `${perm}[${installedAppId}]` : perm
-        );
-      }
-
+      // Pass the requested permissions through unscoped. Rewriting them to
+      // `context:*[<application-id>]` mints tokens core rejects: bracket params
+      // on context permissions are context ids, and `POST /jsonrpc` /
+      // `GET|POST /admin-api/contexts` require Global scope. Since core
+      // 0.11.0-rc.9 enforces token scopes, an app-id-scoped token 403s on all
+      // of those routes and the app loops back to login forever.
       const response = await generateClientKeyDirect({
         context_id: contextId || '',
         context_identity: identity || '',
-        permissions: scopedPermissions,
+        permissions,
       });
 
       if (response.access_token && response.refresh_token) {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -19,6 +19,7 @@ export default defineConfig({
       '**/cypress/**',
       '**/.{idea,git,cache,output,temp}/**',
       '**/tests/**', // Exclude Playwright tests
+      '**/e2e/**', // Playwright specs live here — vitest must not collect them
     ],
     server: {
       deps: {


### PR DESCRIPTION
## Problem

On core **0.11.0-rc.9** every app fails login: after the auth callback the app gets `403` on `GET /admin-api/contexts` and is redirected back to the login page in an endless loop.

Root cause chain:

1. Core rc.9 (calimero-network/core#3040) made the node auth guard **enforce token permission scopes** and default-deny `/admin-api/*`. Before rc.9 only token validity was checked, so scope mismatches were invisible.
2. This flow rewrote every requested context permission to `context:*[<application-id>]` before minting the client key.
3. Core's permission model treats bracket params on context permissions as **context ids**, and its route mappings require **Global** scope for:
   - `POST /jsonrpc` → `context:execute` (Global) — core's own `test_jsonrpc_permissions` asserts a scoped grant is insufficient
   - `GET /admin-api/contexts` → `context:list` (Global)
   - `POST /admin-api/contexts` → `context:create` (Global)
4. `matches_scope(Specific([app-id]), Global)` is false → 403 on all of the above. mero-react gates `isAuthenticated` on `GET /admin-api/contexts`, so the app loops back to login forever — and even past login the token could not execute a single RPC.

## Fix

Pass the app-requested permissions (`context:execute`, `context:list`, `context:create`) through **unscoped**, in both `LoginView.handleContextAndIdentitySelect` and `PackageFlow.generateAndRedirect`. Core still prepends the context binding `context[<ctx-id>,<identity>]` itself when a context is selected.

This restores login + RPC for **all apps on their next login** with no app-side changes (the broken tokens are replaced when the user logs in again).

## Note on least privilege

App-id scoping was a nice intent, but core has no way to honor it today: `/jsonrpc` scope checking is path-based (the context id lives in the request body) and there is no scoped mapping for context creation. Re-introducing scoping needs core-side support first (body-aware `/jsonrpc` mapping + per-application create route). Until then the unscoped token matches what the permission screen shows the user.

## Testing

- `npm run build` ✅
- `npm test` — 57/57 unit tests pass (4 suite-level failures are pre-existing on master: vitest picks up Playwright specs)
- Playwright e2e suite fails identically on unmodified master (bit-rotted config), verified as pre-existing

🤖 Generated with [Claude Code](https://claude.com/claude-code)