### PR TITLE
fix(auth): drop grants pre-rc.11 nodes reject instead of dead-ending login

### DIFF
--- a/src/__tests__/client-key-grant-fallback.test.tsx
+++ b/src/__tests__/client-key-grant-fallback.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * Contract pin: minting a client key degrades gracefully on nodes that
+ * predate core 0.11.0-rc.11 (PR calimero-network/core#3201).
+ *
+ * Apps (via mero-react, PR calimero-network/mero-react#42) request extra
+ * grants at login: `namespace`, `group`, `blob`, `context:alias`. Older nodes
+ * (rc.10 and earlier) reject the WHOLE mint with a 400 when any requested
+ * grant string doesn't parse: `generate_client_key_handler` validates each
+ * permission via `root_key.has_permission()`
+ * (crates/auth/src/api/handlers/client_keys.rs), and `Key::has_permission`
+ * fails on unparseable strings before any admin short-circuit. Without a
+ * fallback, a new app on an old node dead-ends at login with
+ * "Root key does not have permission: namespace".
+ *
+ * `mintClientKeyWithGrantFallback` retries the mint without the rejected
+ * grant, one grant per round, but NEVER drops the base `context:*` trio —
+ * a rejection of those is a genuine permission failure and must surface.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../vitest.setup';
+import { mintClientKeyWithGrantFallback } from '../utils/mintClientKey';
+
+const BASE_TRIO = ['context:create', 'context:list', 'context:execute'];
+const NEW_GRANTS = ['namespace', 'group', 'blob', 'context:alias'];
+const REQUESTED = [...BASE_TRIO, ...NEW_GRANTS];
+
+/**
+ * Mock an rc.10-era node: 400 the whole mint whenever the request contains
+ * any grant in `unsupported`, naming the first offender the way core's auth
+ * service does. Records the permissions of every attempt.
+ */
+function mockNode(unsupported: string[], attempts: string[][]) {
+  server.use(
+    http.post('*/admin/client-key', async ({ request }) => {
+      const body = (await request.json()) as { permissions: string[] };
+      attempts.push(body.permissions);
+
+      const offender = body.permissions.find((p) => unsupported.includes(p));
+      if (offender) {
+        return HttpResponse.json(
+          { error: `Root key does not have permission: ${offender}` },
+          { status: 400 },
+        );
+      }
+      return HttpResponse.json({
+        data: { access_token: 'access', refresh_token: 'refresh' },
+      });
+    }),
+  );
+}
+
+const mint = () =>
+  mintClientKeyWithGrantFallback({
+    context_id: '',
+    context_identity: '',
+    permissions: REQUESTED,
+  });
+
+describe('client-key grant fallback (pre-rc.11 nodes)', () => {
+  let warn: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    localStorage.clear();
+    warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  it('passes the new grants through untouched when the node accepts them', async () => {
+    const attempts: string[][] = [];
+    mockNode([], attempts);
+
+    const response = await mint();
+
+    expect(response.access_token).toBe('access');
+    expect(attempts).toHaveLength(1);
+    expect([...attempts[0]].sort()).toEqual([...REQUESTED].sort());
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('retries without `namespace` on a 400 naming it, keeping the rest', async () => {
+    const attempts: string[][] = [];
+    mockNode(['namespace'], attempts);
+
+    const response = await mint();
+
+    expect(response.access_token).toBe('access');
+    expect(attempts).toHaveLength(2);
+    expect([...attempts[1]].sort()).toEqual(
+      [...BASE_TRIO, 'group', 'blob', 'context:alias'].sort(),
+    );
+    expect(warn).toHaveBeenCalledWith(
+      'node does not support grant namespace — dropping (pre-rc.11 core)',
+    );
+  });
+
+  it('drops group/blob/context:alias across repeated 400s and succeeds with the base trio', async () => {
+    const attempts: string[][] = [];
+    mockNode(NEW_GRANTS, attempts);
+
+    const response = await mint();
+
+    expect(response.access_token).toBe('access');
+    // One rejection per unsupported grant, then the accepted mint.
+    expect(attempts).toHaveLength(NEW_GRANTS.length + 1);
+    expect([...attempts.at(-1)!].sort()).toEqual([...BASE_TRIO].sort());
+    for (const grant of NEW_GRANTS) {
+      expect(warn).toHaveBeenCalledWith(
+        `node does not support grant ${grant} — dropping (pre-rc.11 core)`,
+      );
+    }
+  });
+
+  it('does NOT retry when the node rejects a base grant (context:execute) — the error surfaces', async () => {
+    const attempts: string[][] = [];
+    mockNode(['context:execute'], attempts);
+
+    await expect(mint()).rejects.toThrow(
+      'Root key does not have permission: context:execute',
+    );
+    expect(attempts).toHaveLength(1);
+    expect(warn).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/auth/LoginView.tsx
+++ b/src/components/auth/LoginView.tsx
@@ -24,6 +24,7 @@ import { UsernamePasswordForm } from './UsernamePasswordForm';
 import { ApplicationInstallCheck } from '../applications/ApplicationInstallCheck';
 import { ManifestProcessor } from '../manifest';
 import { normalizePermissions } from '../../utils/permissions';
+import { mintClientKeyWithGrantFallback } from '../../utils/mintClientKey';
 import { AppMode } from '../../types/flows';
 
 interface SignedMessage {
@@ -442,8 +443,11 @@ const LoginView: React.FC = () => {
       // core 0.11.0-rc.9 enforces token scopes (default-deny on /admin-api/*),
       // an application-id-scoped token is rejected with 403 on all of those
       // routes, which locks every app in a redirect-back-to-login loop.
+      //
+      // The fallback wrapper drops grants that pre-rc.11 nodes reject
+      // (namespace/group/blob/context:alias) instead of dead-ending login.
 
-      const response = await generateClientKeyDirect({
+      const response = await mintClientKeyWithGrantFallback({
         context_id: contextId || '',
         context_identity: identity || '',
         permissions,

--- a/src/flows/PackageFlow.tsx
+++ b/src/flows/PackageFlow.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useState } from 'react';
-import { generateClientKeyDirect, getAppEndpointKey } from '../lib/mero';
+import { getAppEndpointKey } from '../lib/mero';
+import { mintClientKeyWithGrantFallback } from '../utils/mintClientKey';
 import { ManifestProcessor } from '../components/manifest/ManifestProcessor';
 import { PermissionsView } from '../components/permissions/PermissionsView';
 import { ContextSelector } from '../components/context/ContextSelector';
@@ -99,7 +100,10 @@ export const PackageFlow: React.FC<PackageFlowProps> = ({
       // `GET|POST /admin-api/contexts` require Global scope. Since core
       // 0.11.0-rc.9 enforces token scopes, an app-id-scoped token 403s on all
       // of those routes and the app loops back to login forever.
-      const response = await generateClientKeyDirect({
+      //
+      // The fallback wrapper drops grants that pre-rc.11 nodes reject
+      // (namespace/group/blob/context:alias) instead of dead-ending login.
+      const response = await mintClientKeyWithGrantFallback({
         context_id: contextId || '',
         context_identity: identity || '',
         permissions,

--- a/src/utils/mintClientKey.ts
+++ b/src/utils/mintClientKey.ts
@@ -1,0 +1,65 @@
+import {
+  generateClientKeyDirect,
+  GenerateClientKeyRequest,
+  GenerateClientKeyResponse,
+} from '../lib/mero';
+
+/**
+ * Mint a client key, degrading gracefully on nodes that predate core
+ * 0.11.0-rc.11 (PR calimero-network/core#3201).
+ *
+ * Apps (via mero-react, PR calimero-network/mero-react#42) now request extra
+ * grants at login: `namespace`, `group`, `blob`, `context:alias`. Newer nodes
+ * accept them, but older nodes reject the ENTIRE mint with a 400 when any
+ * requested grant string doesn't parse: `generate_client_key_handler`
+ * validates each permission via `root_key.has_permission()`, and
+ * `Key::has_permission` fails on unparseable strings before any admin
+ * short-circuit. Without a fallback, a new app on an old node dead-ends at
+ * login with "Root key does not have permission: namespace".
+ *
+ * Strategy: when the mint fails and the error message names a specific
+ * permission (`... does not have permission: <grant>`), drop that grant from
+ * the request and retry, until the mint succeeds or nothing droppable is
+ * left. The base `context:*` trio is never dropped — if the node rejects one
+ * of THOSE, that's a genuine permission failure and it surfaces as before.
+ * Iterations are capped at the number of originally requested grants.
+ */
+
+/** Grants that must never be silently dropped — the app can't run without them. */
+const BASE_GRANTS = new Set(['context:create', 'context:list', 'context:execute']);
+
+/**
+ * How the node's rejection surfaces here: `generateClientKeyDirect` throws a
+ * plain `Error` whose message is the node's `error.message` (e.g.
+ * "Root key does not have permission: namespace").
+ */
+const MISSING_GRANT_RE = /does not have permission:\s*(\S+)/;
+
+export async function mintClientKeyWithGrantFallback(
+  request: GenerateClientKeyRequest,
+): Promise<GenerateClientKeyResponse> {
+  let permissions = [...request.permissions];
+  // One retry per originally requested grant, at most.
+  const maxRetries = permissions.length;
+
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await generateClientKeyDirect({ ...request, permissions });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      const grant = MISSING_GRANT_RE.exec(message)?.[1];
+
+      if (
+        attempt >= maxRetries || // iteration cap
+        !grant || // not a per-grant rejection — some other failure
+        BASE_GRANTS.has(grant) || // base trio: never dropped, fail as today
+        !permissions.includes(grant) // node named something we didn't request
+      ) {
+        throw err;
+      }
+
+      console.warn(`node does not support grant ${grant} — dropping (pre-rc.11 core)`);
+      permissions = permissions.filter((p) => p !== grant);
+    }
+  }
+}


### PR DESCRIPTION
## Problem

Apps (via the upcoming mero-react release, calimero-network/mero-react#42) now request extra permission grants at login: `namespace`, `group`, `blob`, `context:alias`. Core nodes >= 0.11.0-rc.11 (calimero-network/core#3201) accept them — but **older nodes (rc.10 and earlier) reject the entire client-key mint with a 400** when any requested grant string doesn't parse: `generate_client_key_handler` validates each permission via `root_key.has_permission()` (`crates/auth/src/api/handlers/client_keys.rs`), and `Key::has_permission` fails on unparseable strings before any admin short-circuit. So a new app on an old node dead-ends at login with:

> Root key does not have permission: namespace

## Fix

New shared helper `mintClientKeyWithGrantFallback` (`src/utils/mintClientKey.ts`), used by both mint sites (`LoginView.handleContextAndIdentitySelect` and `PackageFlow.generateAndRedirect`):

- When the mint fails with an error matching `does not have permission: <grant>`, the named grant is removed from the request and the mint is retried — one grant per round, capped at the number of originally requested grants.
- Each dropped grant logs `console.warn("node does not support grant X — dropping (pre-rc.11 core)")`.
- **Never dropped:** the base trio `context:create` / `context:list` / `context:execute`. If the node rejects one of those, that's a genuine permission failure and it surfaces exactly as today.
- On rc.11+ nodes the request goes through untouched on the first attempt — zero behavior change.

## Tests

Four msw contract tests (`src/__tests__/client-key-grant-fallback.test.tsx`, same style as `client-key-permissions.test.tsx`) pin: clean passthrough of the new grants, single-grant (`namespace`) retry keeping the rest, cascading 400s dropping `group`/`blob`/`context:alias` down to the base trio, and no retry when `context:execute` is named. Full suite: 62/62 green; `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)