### PR TITLE
fix(providers): stop presenting a failed providers request as "No providers available"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-react",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/components/auth/EnsureAdminSession.tsx
+++ b/src/components/auth/EnsureAdminSession.tsx
@@ -41,16 +41,21 @@ export const EnsureAdminSession: React.FC<EnsureAdminSessionProps> = ({ children
   const [usernamePasswordLoading, setUsernamePasswordLoading] = useState(false);
 
   /**
-   * Load available authentication providers
+   * Load available authentication providers.
+   * Returns true on success so callers can avoid rendering the provider list
+   * (and its misleading "No providers available" empty state) when the
+   * request itself failed — e.g. the node is unreachable.
    */
-  const loadProviders = useCallback(async () => {
+  const loadProviders = useCallback(async (): Promise<boolean> => {
     try {
       const mero = getMero();
       const response: any = await mero.auth.getProviders();
       setProviders((response as any)?.data?.providers ?? (response as any)?.providers ?? []);
+      return true;
     } catch (err) {
       console.error('Failed to load providers:', err);
       setError(err instanceof Error ? err.message : 'Failed to load authentication providers');
+      return false;
     }
   }, []);
 
@@ -108,9 +113,11 @@ export const EnsureAdminSession: React.FC<EnsureAdminSessionProps> = ({ children
         clearRefreshToken();
       }
       
-      // No valid token, need to authenticate
-      await loadProviders();
-      setShowProviders(true);
+      // No valid token, need to authenticate.
+      // Only show the provider list if it actually loaded — otherwise fall
+      // through to the ErrorView, which offers a retry.
+      const loaded = await loadProviders();
+      setShowProviders(loaded);
       setLoading(false);
     };
     
@@ -192,8 +199,8 @@ export const EnsureAdminSession: React.FC<EnsureAdminSessionProps> = ({ children
         onRetry={async () => {
           setError(null);
           setLoading(true);
-          await loadProviders();
-          setShowProviders(true);
+          const loaded = await loadProviders();
+          setShowProviders(loaded);
           setLoading(false);
         }}
       />
@@ -207,6 +214,13 @@ export const EnsureAdminSession: React.FC<EnsureAdminSessionProps> = ({ children
         onProviderSelect={handleProviderSelect}
         loading={loading}
         error={error}
+        onRetry={async () => {
+          setError(null);
+          setLoading(true);
+          const loaded = await loadProviders();
+          setShowProviders(loaded);
+          setLoading(false);
+        }}
       />
     );
   }

--- a/src/components/auth/LoginView.tsx
+++ b/src/components/auth/LoginView.tsx
@@ -547,6 +547,7 @@ const LoginView: React.FC = () => {
           providers={providers}
           onProviderSelect={handleProviderSelect}
           loading={loading}
+          onRetry={loadProviders}
         />
       )}
 

--- a/src/components/auth/LoginView.tsx
+++ b/src/components/auth/LoginView.tsx
@@ -53,15 +53,20 @@ const LoginView: React.FC = () => {
   /**
    * Load available authentication providers from the auth service and update UI state.
    * Used when showing the provider selector or after an invalid/cleared session.
+   * Returns true on success so callers can avoid rendering the provider list
+   * (and its misleading "No providers available" empty state) when the
+   * request itself failed — e.g. the node is unreachable.
    */
-  const loadProviders = useCallback(async () => {
+  const loadProviders = useCallback(async (): Promise<boolean> => {
     try {
       const mero = getMero();
       const response: any = await mero.auth.getProviders();
       setProviders((response as any)?.data?.providers ?? (response as any)?.providers ?? []);
+      return true;
     } catch (err) {
       console.error('Failed to load providers:', err);
       setError(err instanceof Error ? err.message : 'Failed to load authentication providers');
+      return false;
     }
   }, []);
 
@@ -99,8 +104,8 @@ const LoginView: React.FC = () => {
       console.error('Token validation failed:', err);
       clearAccessToken();
       clearRefreshToken();
-      setShowProviders(true);
-      await loadProviders();
+      const loaded = await loadProviders();
+      setShowProviders(loaded);
       return false;
     }
   };
@@ -142,12 +147,12 @@ const LoginView: React.FC = () => {
           setShowApplicationInstallCheck(true);
         }
       } else {
-        setShowProviders(true);
-        await loadProviders();
+        const loaded = await loadProviders();
+        setShowProviders(loaded);
       }
     } else {
-      setShowProviders(true);
-      await loadProviders();
+      const loaded = await loadProviders();
+      setShowProviders(loaded);
     }
     setLoading(false);
   };
@@ -196,8 +201,8 @@ const LoginView: React.FC = () => {
    * Force showing providers and reloading available providers (used when restarting login).
    */
   const handleNewLogin = async () => {
-    await loadProviders();
-    setShowProviders(true);
+    const loaded = await loadProviders();
+    setShowProviders(loaded);
   };
 
   /**

--- a/src/components/providers/ProviderSelector.tsx
+++ b/src/components/providers/ProviderSelector.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 interface Provider { name: string; type: string; description?: string; configured?: boolean; config?: Record<string, unknown>; [key: string]: unknown; }
 import {
+  Button,
   Card,
   CardContent,
   CardHeader,
@@ -19,6 +20,7 @@ interface ProviderSelectorProps {
   onProviderSelect: (provider: Provider) => void;
   loading: boolean;
   error?: string | null;
+  onRetry?: () => void;
 }
 
 const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
@@ -32,21 +34,37 @@ const ProviderSelector: React.FC<ProviderSelectorProps> = ({
   onProviderSelect,
   loading,
   error,
+  onRetry,
 }) => {
   if (loading) {
     return <Loader />;
   }
 
   if (providers.length === 0) {
+    // An empty list can mean two very different things: the node genuinely
+    // has no providers configured, or the providers request itself failed
+    // (node unreachable, proxy error, ...). Don't present a failed request
+    // as "nothing is configured" — and always offer a way out.
     return (
       <PageShell>
         <Card variant="rounded" color="var(--color-border-brand)">
           <CardContent>
             <EmptyState
-              title="No providers available"
-              description="No authentication providers are configured on this node."
+              title={error ? 'Unable to load providers' : 'No providers available'}
+              description={
+                error
+                  ? `Could not fetch authentication providers from the node: ${error}`
+                  : 'No authentication providers are configured on this node.'
+              }
               variant="minimal"
             />
+            <Stack spacing="sm" align="center" style={{ marginTop: '12px' }}>
+              {onRetry ? (
+                <Button onClick={onRetry}>Retry</Button>
+              ) : (
+                <Button onClick={() => window.location.reload()}>Reload</Button>
+              )}
+            </Stack>
           </CardContent>
         </Card>
       </PageShell>


### PR DESCRIPTION
## Problem

When the `/auth/providers` request fails — node unreachable, or the desktop app's fetch proxy dying on a Tauri IPC scope rejection (see calimero-network/tauri-app#145) — the login page dead-ends on:

> **No providers available**
> No authentication providers are configured on this node.

That message is wrong (the node has providers; the request never reached it) and the page offers no way to recover.

Cause: `EnsureAdminSession.loadProviders` swallowed the fetch error into `providers = []` and then unconditionally set `showProviders`, and `ProviderSelector` returns its empty state before ever looking at its `error` prop.

## Fix

- `loadProviders` now returns whether it succeeded; the provider list only renders on success, otherwise the `ErrorView` (with a retry that re-gates on success) shows
- `ProviderSelector`'s empty state distinguishes **"Unable to load providers: <error>"** from a genuine zero-provider node, and always offers a Retry/Reload button
- `LoginView` wires a retry into `ProviderSelector` as well

## Testing

- `npm run build` passes
- `npm test` — 58/58 unit tests pass

Companion PR: calimero-network/tauri-app#145 fixes the desktop-side root cause (proxy must not run on plain-HTTP pages; IPC scopes now cover the node host).

🤖 Generated with [Claude Code](https://claude.com/claude-code)