### PR TITLE
fix(auth): survive single-use refresh tokens (rotation, read-only session probe)

### DIFF
--- a/e2e/live-login.spec.ts
+++ b/e2e/live-login.spec.ts
@@ -65,3 +65,51 @@ test('admin login flow delivers working tokens to the callback', async ({
   });
   expect(res.status()).toBe(200);
 });
+
+/**
+ * Returning user: the session check must be READ-ONLY.
+ *
+ * Refresh tokens are single-use since calimero-network/core#3083 — every
+ * POST /auth/refresh consumes the one it is given. This screen used to probe
+ * liveness *with* /auth/refresh, so every mount spent a refresh token; the
+ * rotated replacement was never persisted (MeroJs had no tokenStore), so the
+ * next load replayed the consumed one and the node revoked the family.
+ *
+ * The probe is now HEAD /auth/validate, which consumes nothing.
+ */
+test('a returning user resumes the session without spending a refresh token', async ({
+  page,
+}) => {
+  const callback = 'http://localhost:4173/';
+  const loginUrl =
+    `/auth/login?callback-url=${encodeURIComponent(callback)}` +
+    `&permissions=admin&app-url=${encodeURIComponent(NODE_URL)}`;
+
+  await page.goto(loginUrl);
+  await page.getByText('Username/Password').click();
+  await page.getByPlaceholder('Enter your username').fill(USERNAME);
+  await page.getByPlaceholder('Enter your password').fill(PASSWORD);
+  await page.getByRole('button', { name: 'Sign In' }).click();
+  await page.getByRole('button', { name: 'Generate Token' }).waitFor();
+
+  const storedRefreshToken = await page.evaluate(() =>
+    localStorage.getItem('calimero_refresh_token'),
+  );
+  expect(storedRefreshToken).toBeTruthy();
+
+  const refreshCalls: string[] = [];
+  page.on('request', (req) => {
+    if (req.url().endsWith('/auth/refresh')) refreshCalls.push(req.url());
+  });
+
+  // Come back to the login screen with the session still in localStorage.
+  await page.goto(loginUrl);
+
+  // Straight through to consent — no provider screen, no credentials.
+  await expect(page.getByRole('button', { name: 'Generate Token' })).toBeVisible();
+
+  expect(refreshCalls).toEqual([]);
+  await expect
+    .poll(() => page.evaluate(() => localStorage.getItem('calimero_refresh_token')))
+    .toBe(storedRefreshToken);
+});

--- a/src/__tests__/mocks.test.ts
+++ b/src/__tests__/mocks.test.ts
@@ -6,11 +6,22 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { fixtures } from '../mocks/fixtures';
 import { updateScenario, resetScenario } from '../mocks/handlers';
 
+/** POST /auth/refresh with a token pair. */
+const refresh = (tokens: { access_token: string; refresh_token: string }) =>
+  fetch('http://node1.127.0.0.1.nip.io/auth/refresh', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      access_token: tokens.access_token,
+      refresh_token: tokens.refresh_token,
+    }),
+  });
+
 describe('MSW Mock Server', () => {
   beforeEach(() => {
     resetScenario();
   });
-  
+
   describe('Auth API Mocks', () => {
     it('should mock getProviders endpoint', async () => {
       const response = await fetch('http://node1.127.0.0.1.nip.io/auth/providers');
@@ -22,22 +33,67 @@ describe('MSW Mock Server', () => {
     });
     
     it('should mock token refresh endpoint', async () => {
-      const response = await fetch('http://node1.127.0.0.1.nip.io/auth/refresh', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          access_token: 'test_access',
-          refresh_token: 'test_refresh',
-        }),
-      });
-      
+      const response = await refresh(fixtures.tokens.admin);
+
       const payload = await response.json();
-      
+
       expect(response.ok).toBe(true);
       expect(payload.data.access_token).toBeTruthy();
       expect(payload.data.refresh_token).toBeTruthy();
     });
-    
+
+    /**
+     * core#3083: refresh tokens are single-use. The mock must rotate, or the
+     * suite goes green against a client that replays consumed tokens — which
+     * is exactly how the no-tokenStore bug survived CI.
+     */
+    it('should rotate the refresh token on every refresh', async () => {
+      const first = await (await refresh(fixtures.tokens.admin)).json();
+      expect(first.data.refresh_token).not.toBe(fixtures.tokens.admin.refresh_token);
+
+      const second = await (await refresh(first.data)).json();
+      expect(second.data.refresh_token).not.toBe(first.data.refresh_token);
+      expect(second.data.access_token).not.toBe(first.data.access_token);
+    });
+
+    it('should reject a replayed refresh token with x-auth-error: token_reuse', async () => {
+      await refresh(fixtures.tokens.admin);
+
+      // Same (now consumed) token again: the node reads this as theft.
+      const replay = await refresh(fixtures.tokens.admin);
+
+      expect(replay.status).toBe(401);
+      expect(replay.headers.get('x-auth-error')).toBe('token_reuse');
+    });
+
+    it('should revoke the whole family once a replay is detected', async () => {
+      const rotated = await (await refresh(fixtures.tokens.admin)).json();
+      await refresh(fixtures.tokens.admin); // replay → family revoked
+
+      const validate = await fetch('http://node1.127.0.0.1.nip.io/auth/validate', {
+        method: 'HEAD',
+        headers: { Authorization: `Bearer ${rotated.data.access_token}` },
+      });
+
+      expect(validate.status).toBe(401);
+      expect(validate.headers.get('x-auth-error')).toBe('token_revoked');
+    });
+
+    it('should mock the read-only /auth/validate session gate', async () => {
+      const live = await fetch('http://node1.127.0.0.1.nip.io/auth/validate', {
+        method: 'HEAD',
+        headers: { Authorization: `Bearer ${fixtures.tokens.admin.access_token}` },
+      });
+      expect(live.status).toBe(200);
+
+      const stale = await fetch('http://node1.127.0.0.1.nip.io/auth/validate', {
+        method: 'HEAD',
+        headers: { Authorization: 'Bearer stale_access_token' },
+      });
+      expect(stale.status).toBe(401);
+      expect(stale.headers.get('x-auth-error')).toBe('token_expired');
+    });
+
     it('should mock username/password authentication', async () => {
       const response = await fetch('http://node1.127.0.0.1.nip.io/auth/token', {
         method: 'POST',

--- a/src/components/auth/EnsureAdminSession.tsx
+++ b/src/components/auth/EnsureAdminSession.tsx
@@ -1,12 +1,10 @@
 import React, { useState, useCallback, useEffect } from 'react';
-import { 
-  getMero, 
-  getAccessToken, 
-  getRefreshToken, 
-  setAccessToken, 
-  setRefreshToken,
-  clearAccessToken,
-  clearRefreshToken 
+import {
+  getMero,
+  hasLiveSession,
+  isAuthRevoked,
+  setTokens,
+  clearTokens,
 } from '../../lib/mero';
 interface Provider { name: string; type: string; description?: string; configured?: boolean; config?: Record<string, unknown>; [key: string]: unknown; }
 import ProviderSelector from '../providers/ProviderSelector';
@@ -60,69 +58,36 @@ export const EnsureAdminSession: React.FC<EnsureAdminSessionProps> = ({ children
   }, []);
 
   /**
-   * Validate or refresh existing admin token
-   */
-  const validateToken = useCallback(async (accessToken: string, refreshToken: string): Promise<boolean> => {
-    try {
-      const mero = getMero();
-      const response = await mero.auth.refreshToken({
-        access_token: accessToken,
-        refresh_token: refreshToken
-      });
-
-      // Token was refreshed successfully
-      if ((response as any).data.access_token && (response as any).data.refresh_token) {
-        setAccessToken((response as any).data.access_token);
-        setRefreshToken((response as any).data.refresh_token);
-        return true;
-      }
-
-      return false;
-    } catch (err) {
-      // Check if error message indicates token is still valid
-      const errorMessage = err instanceof Error ? err.message : '';
-      if (errorMessage.includes('Access token still valid') || errorMessage.includes('token valid')) {
-        return true;
-      }
-      
-      console.error('Token validation failed:', err);
-      return false;
-    }
-  }, []);
-
-  /**
-   * Check for existing session on mount
+   * Check for existing session on mount.
+   *
+   * The probe is read-only (HEAD /auth/validate). It used to be a
+   * POST /auth/refresh, which since core#3083 consumes a single-use refresh
+   * token on every single mount — and which the node rejects outright while
+   * the access token is still valid, so it never even worked as a liveness
+   * check. mero-js refreshes on its own when a real request comes back 401
+   * `token_expired`, and now persists the rotated bundle.
    */
   useEffect(() => {
     const checkSession = async () => {
-      const existingAccessToken = getAccessToken();
-      const existingRefreshToken = getRefreshToken();
-      
-      if (existingAccessToken && existingRefreshToken) {
-        const isValid = await validateToken(existingAccessToken, existingRefreshToken);
-        
-        if (isValid) {
-          setHasAdminToken(true);
-          onReady?.();
-          setLoading(false);
-          return;
-        }
-        
-        // Token invalid, clear and show providers
-        clearAccessToken();
-        clearRefreshToken();
+      if (await hasLiveSession()) {
+        setHasAdminToken(true);
+        onReady?.();
+        setLoading(false);
+        return;
       }
-      
-      // No valid token, need to authenticate.
-      // Only show the provider list if it actually loaded — otherwise fall
-      // through to the ErrorView, which offers a retry.
+
+      // No live session — drop whatever is left (a revoked family included)
+      // and authenticate again. Only show the provider list if it actually
+      // loaded; otherwise fall through to the ErrorView, which offers a retry.
+      clearTokens();
+
       const loaded = await loadProviders();
       setShowProviders(loaded);
       setLoading(false);
     };
-    
+
     checkSession();
-  }, [validateToken, loadProviders, onReady]);
+  }, [loadProviders, onReady]);
 
   /**
    * Handle provider selection
@@ -131,11 +96,12 @@ export const EnsureAdminSession: React.FC<EnsureAdminSessionProps> = ({ children
     if (provider.name === 'user_password') {
       setShowProviders(false);
       setShowUsernamePasswordForm(true);
-    } else if (provider.name === 'near_wallet') {
-      setError('NEAR wallet authentication not yet implemented');
-    } else {
-      setError(`Provider ${provider.name} is not supported`);
+      return;
     }
+
+    // Nothing else is supported: the wallet path needed GET /auth/challenge,
+    // which core#3229 removes.
+    setError(`Provider ${provider.name} is not supported`);
   };
 
   /**
@@ -162,8 +128,12 @@ export const EnsureAdminSession: React.FC<EnsureAdminSessionProps> = ({ children
       const response = await mero.auth.generateTokens(tokenPayload) as any;
 
       if ((response as any).data.access_token && (response as any).data.refresh_token) {
-        setAccessToken((response as any).data.access_token);
-        setRefreshToken((response as any).data.refresh_token);
+        // MeroJs takes ownership of the bundle and persists it — and every
+        // rotation it performs later — through the token store.
+        setTokens({
+          access_token: (response as any).data.access_token,
+          refresh_token: (response as any).data.refresh_token,
+        });
         setHasAdminToken(true);
         setShowUsernamePasswordForm(false);
         onReady?.();
@@ -172,6 +142,12 @@ export const EnsureAdminSession: React.FC<EnsureAdminSessionProps> = ({ children
       }
     } catch (err) {
       console.error('Authentication error:', err);
+      if (isAuthRevoked(err)) {
+        // The family is dead; a retry with these tokens can only fail again.
+        clearTokens();
+        setShowUsernamePasswordForm(false);
+        setShowProviders(await loadProviders());
+      }
       setError(err instanceof Error ? err.message : 'Authentication failed');
     } finally {
       setUsernamePasswordLoading(false);

--- a/src/components/auth/LoginView.tsx
+++ b/src/components/auth/LoginView.tsx
@@ -1,20 +1,14 @@
 import React, { useState, useCallback, useEffect } from 'react';
 import ProviderSelector from '../providers/ProviderSelector';
-import { NetworkId, setupWalletSelector } from '@near-wallet-selector/core';
-import { setupMyNearWallet } from '@near-wallet-selector/my-near-wallet';
-import { Buffer } from 'buffer';
 import { handleUrlParams, getStoredUrlParam, clearStoredUrlParams } from '../../utils/urlParams';
 import {
   getMero,
   generateClientKeyDirect,
-  clearAccessToken,
-  clearRefreshToken,
-  getAccessToken,
   getAppEndpointKey,
-  getRefreshToken,
-  setAccessToken,
-  setRefreshToken,
-  extractTokens
+  hasLiveSession,
+  isAuthRevoked,
+  setTokens,
+  clearTokens,
 } from '../../lib/mero';
 interface Provider { name: string; type: string; description?: string; configured?: boolean; config?: Record<string, unknown>; [key: string]: unknown; }
 import { ErrorView } from '../common/ErrorView';
@@ -25,12 +19,6 @@ import { ApplicationInstallCheck } from '../applications/ApplicationInstallCheck
 import { ManifestProcessor } from '../manifest';
 import { normalizePermissions } from '../../utils/permissions';
 import { AppMode } from '../../types/flows';
-
-interface SignedMessage {
-  accountId: string;
-  publicKey: string;
-  signature: string;
-}
 
 const LoginView: React.FC = () => {
   const [providers, setProviders] = useState<Provider[]>([]);
@@ -71,89 +59,48 @@ const LoginView: React.FC = () => {
   }, []);
 
   /**
-   * Validate or refresh an existing root token pair.
-   *
-   * @param accessToken - Current access token
-   * @param refreshToken - Current refresh token
-   * @returns Promise resolving to true when session remains valid (possibly rotated), false otherwise
-   */
-  const checkIfTokenIsValid = async (accessToken: string, refreshToken: string) => {
-    try {
-      const mero = getMero();
-      const response: any = await mero.auth.refreshToken({
-        access_token: accessToken,
-        refresh_token: refreshToken
-      });
-      
-      if ((response as any).data.access_token && (response as any).data.refresh_token) {
-        setAccessToken((response as any).data.access_token);
-        setRefreshToken((response as any).data.refresh_token);
-        setShowProviders(false);
-        return true;
-      }
-
-      throw new Error('Failed to validate token');
-    } catch (err) {
-      // Check if error message indicates token is still valid
-      const errorMessage = err instanceof Error ? err.message : '';
-      if (errorMessage.includes('Access token still valid') || errorMessage.includes('token valid')) {
-        setShowProviders(false);
-        return true;
-      }
-      
-      console.error('Token validation failed:', err);
-      clearAccessToken();
-      clearRefreshToken();
-      const loaded = await loadProviders();
-      setShowProviders(loaded);
-      return false;
-    }
-  };
-
-  /**
    * Auto-continue flow bootstrap.
-   * If a valid root token exists, skip providers and show next screen (permissions/install) based on URL permissions.
+   * If a live root session exists, skip providers and show next screen (permissions/install) based on URL permissions.
    * Otherwise, show providers and load provider list.
+   *
+   * The session check is read-only (HEAD /auth/validate). It used to be a
+   * POST /auth/refresh, which since core#3083 consumes a single-use refresh
+   * token on every mount — and which the node rejects outright while the
+   * access token is still valid, so it never worked as a liveness check
+   * either. mero-js refreshes on its own when a real request comes back 401
+   * `token_expired`, and now persists the rotated bundle.
    */
   const checkExistingSession = async () => {
-    // Check for manifest-based flows first
-    const manifestUrl = getStoredUrlParam('manifest-url');
-    
-    
-    // Don't bypass authentication for manifest flows - let user authenticate first
-    // The manifest processing will happen after authentication
-    
-    const existingAccessToken = getAccessToken();
-    const existingRefreshToken = getRefreshToken();
-    
-    if (existingAccessToken && existingRefreshToken) {
-      const isValid = await checkIfTokenIsValid(existingAccessToken, existingRefreshToken);
-      if (isValid) {
-        // Automatically continue session and check permissions
-        const permissionsParam = getStoredUrlParam('permissions');
-        const permissions = permissionsParam ? permissionsParam.split(',') : [];
-        const hasAdminPermissions = permissions.includes('admin');
-        
-        // Check for manifest flows after authentication
-        const manifestUrl = getStoredUrlParam('manifest-url');
-        
-        // For manifest flows, show permissions FIRST
-        if (manifestUrl) {
-          // Store manifest data for PermissionsView to display
-          setShowPermissionsView(true);
-        } else if (hasAdminPermissions) {
-          setShowPermissionsView(true);
-        } else {
-          setShowApplicationInstallCheck(true);
-        }
+    // Don't bypass authentication for manifest flows - let user authenticate first.
+    // The manifest processing will happen after authentication.
+    if (await hasLiveSession()) {
+      setShowProviders(false);
+
+      // Automatically continue session and check permissions
+      const permissionsParam = getStoredUrlParam('permissions');
+      const permissions = permissionsParam ? permissionsParam.split(',') : [];
+      const hasAdminPermissions = permissions.includes('admin');
+
+      // Check for manifest flows after authentication
+      const manifestUrl = getStoredUrlParam('manifest-url');
+
+      // For manifest flows, show permissions FIRST
+      if (manifestUrl) {
+        // Store manifest data for PermissionsView to display
+        setShowPermissionsView(true);
+      } else if (hasAdminPermissions) {
+        setShowPermissionsView(true);
       } else {
-        const loaded = await loadProviders();
-        setShowProviders(loaded);
+        setShowApplicationInstallCheck(true);
       }
     } else {
+      // Whatever is left is unusable (a revoked family included) — drop it and
+      // authenticate again.
+      clearTokens();
       const loaded = await loadProviders();
       setShowProviders(loaded);
     }
+
     setLoading(false);
   };
   
@@ -206,6 +153,26 @@ const LoginView: React.FC = () => {
   };
 
   /**
+   * A revoked token family (core#3083) is terminal — no retry can fix it. Drop
+   * the session and send the user back to the provider screen rather than park
+   * them on an error whose Retry button can only fail again.
+   *
+   * @returns true when the error was a revocation and has been handled
+   */
+  const handleRevokedSession = async (err: unknown): Promise<boolean> => {
+    if (!isAuthRevoked(err)) return false;
+
+    clearTokens();
+    setShowPermissionsView(false);
+    setShowApplicationInstallCheck(false);
+    setShowManifestProcessor(false);
+    setShowUsernamePasswordForm(false);
+    setError(null);
+    setShowProviders(await loadProviders());
+    return true;
+  };
+
+  /**
    * Handle username/password authentication flow.
    * Exchanges credentials for a root token, then routes to permissions or install check.
    *
@@ -233,9 +200,13 @@ const LoginView: React.FC = () => {
       const tokenResponse = await mero.auth.generateTokens(tokenPayload) as any;
 
       if ((tokenResponse as any).data.access_token && (tokenResponse as any).data.refresh_token) {
-        setAccessToken((tokenResponse as any).data.access_token);
-        setRefreshToken((tokenResponse as any).data.refresh_token);
-        
+        // MeroJs takes ownership of the bundle and persists it — and every
+        // rotation it performs later — through the token store.
+        setTokens({
+          access_token: (tokenResponse as any).data.access_token,
+          refresh_token: (tokenResponse as any).data.refresh_token,
+        });
+
         // Check for manifest/package flows after authentication
         const manifestUrl = getStoredUrlParam('manifest-url');
         const packageName = getStoredUrlParam('package-name');
@@ -266,7 +237,9 @@ const LoginView: React.FC = () => {
       }
     } catch (err) {
       console.error('Authentication error:', err);
-      setError(err instanceof Error ? err.message : 'Authentication failed');
+      if (!(await handleRevokedSession(err))) {
+        setError(err instanceof Error ? err.message : 'Authentication failed');
+      }
     } finally {
       setUsernamePasswordLoading(false);
     }
@@ -274,93 +247,21 @@ const LoginView: React.FC = () => {
 
   /**
    * Handle provider selection.
-   * For near_wallet, performs challenge → sign → token exchange; for user_password, shows the credential form.
-   * Routes to permissions or application install check after a successful root token exchange.
+   * For user_password, shows the credential form. Every other provider is
+   * unsupported: the wallet path this used to run needed GET /auth/challenge,
+   * which core#3229 removes (there is no wallet provider to sign for).
    *
    * @param provider - Selected auth provider metadata
    */
   const handleProviderSelect = async (provider: Provider) => {
-    try {
-      const mero = getMero();
-      
-      if (provider.name === 'near_wallet') {
-        const challengeResponse = await mero.auth.getChallenge() as any;
-        
-        // Provider config may have network info - cast to any for flexibility
-        const providerConfig = (provider as any).config;
-        const selector = await setupWalletSelector({
-          network: providerConfig?.network as NetworkId,
-          modules: [setupMyNearWallet()]
-        });
-
-        const wallet = await selector.wallet('my-near-wallet');
-        
-        let signature;
-        try {
-          signature = await wallet.signMessage({
-            message: (challengeResponse as any)?.data?.challenge ?? (challengeResponse as any)?.challenge,
-            nonce: Buffer.from((challengeResponse as any)?.data?.challenge ?? (challengeResponse as any)?.challenge, 'base64'),
-            recipient: 'calimero',
-            callbackUrl: window.location.href
-          }) as SignedMessage;
-        } catch (err) {
-          // Handle user closing the window
-          if (err instanceof Error && err.message === 'User closed the window') {
-            setShowProviders(true);
-            return;
-          }
-          throw err;
-        }
-
-        const tokenPayload = {
-          auth_method: provider.name as 'near_wallet',
-          public_key: signature.publicKey,
-          client_name: window.location.href,
-          timestamp: Date.now(),
-          permissions: [] as string[],
-          provider_data: {
-            wallet_address: signature.accountId,
-            message: (challengeResponse as any)?.data?.challenge ?? (challengeResponse as any)?.challenge,
-            signature: signature.signature,
-            recipient: 'calimero'
-          }
-        };
-
-        const tokenResponse = await mero.auth.generateTokens(tokenPayload) as any;
-
-        if ((tokenResponse as any).data.access_token && (tokenResponse as any).data.refresh_token) {
-          setAccessToken((tokenResponse as any).data.access_token);
-          setRefreshToken((tokenResponse as any).data.refresh_token);
-          
-          const permissionsParam = getStoredUrlParam('permissions');
-          const permissions = permissionsParam ? permissionsParam.split(',') : [];
-          const hasAdminPermissions = permissions.includes('admin');
-          
-          // Check for manifest flows after authentication
-          const manifestUrl = getStoredUrlParam('manifest-url');
-          
-          // For manifest flows, we need admin permissions, so show PermissionsView first
-          if (manifestUrl && hasAdminPermissions) {
-            setShowPermissionsView(true);
-          } else if (hasAdminPermissions) {
-            setShowPermissionsView(true);
-          } else {
-            setShowApplicationInstallCheck(true);
-          }
-        } else {
-          throw new Error('Failed to get access token');
-        }
-      } else if (provider.name === 'user_password') {
-        setShowProviders(false);
-        setShowUsernamePasswordForm(true);
-      } else {
-        setError(`Provider ${provider.name} is not implemented yet`);
-      }
-    } catch (err) {
-      console.error('Authentication error:', err);
-      setError(err instanceof Error ? err.message : 'Authentication failed');
+    if (provider.name === 'user_password') {
+      setShowProviders(false);
+      setShowUsernamePasswordForm(true);
+      return;
     }
-  };  
+
+    setError(`Provider ${provider.name} is not supported`);
+  };
 
   /**
    * Generate an admin-scoped client key and redirect back to callback with tokens in the URL fragment.
@@ -404,7 +305,9 @@ const LoginView: React.FC = () => {
       }
     } catch (err) {
       console.error('Failed to generate admin client key:', err);
-      setError(err instanceof Error ? err.message : 'Failed to generate admin client key');
+      if (!(await handleRevokedSession(err))) {
+        setError(err instanceof Error ? err.message : 'Failed to generate admin client key');
+      }
     }
   };
 
@@ -489,7 +392,9 @@ const LoginView: React.FC = () => {
       }
     } catch (err) {
       console.error('Failed to generate client key:', err);
-      setError(err instanceof Error ? err.message : 'Failed to generate client key');
+      if (!(await handleRevokedSession(err))) {
+        setError(err instanceof Error ? err.message : 'Failed to generate client key');
+      }
     }
   };
   

--- a/src/lib/__tests__/mero.test.ts
+++ b/src/lib/__tests__/mero.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Regression pins for single-use refresh tokens (calimero-network/core#3083).
+ *
+ * Every POST /auth/refresh consumes the refresh token it is given and returns
+ * a new one. Re-presenting a consumed token is treated as theft: the node
+ * revokes the whole family and answers 401 `x-auth-error: token_reuse`.
+ *
+ * So the rotated token MUST be persisted where the next page load reads it.
+ * Until this PR the MeroJs instance was built with no tokenStore, which makes
+ * mero-js's `tokenStore?.setTokens(...)` a no-op: the rotated token lived only
+ * in memory while localStorage kept the consumed one, and the next reload
+ * replayed it — killing the session.
+ *
+ * The MSW mock models the rotation and the reuse trap (src/mocks/handlers.ts),
+ * so these tests fail against the old lib/mero.ts.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { HTTPError } from '@calimero-network/mero-js';
+import { server } from '../../../vitest.setup';
+import { fixtures } from '../../mocks/fixtures';
+import {
+  AuthRevokedError,
+  clearTokens,
+  generateClientKeyDirect,
+  getAccessToken,
+  getMero,
+  getRefreshToken,
+  hasLiveSession,
+  isAuthRevoked,
+  resetMero,
+  setAppEndpointKey,
+  setTokens,
+} from '../mero';
+
+const NODE_URL = 'http://node1.127.0.0.1.nip.io';
+
+const ACCESS_KEY = 'calimero_access_token';
+const REFRESH_KEY = 'calimero_refresh_token';
+
+/** Seed a session the way a previous page load would have left it. */
+const seedStoredSession = (tokens: { access_token: string; refresh_token: string }) => {
+  localStorage.setItem(ACCESS_KEY, tokens.access_token);
+  localStorage.setItem(REFRESH_KEY, tokens.refresh_token);
+};
+
+/** A fresh page load: the module-level MeroJs instance is gone, storage isn't. */
+const reload = () => resetMero();
+
+/** The access token has aged out; the refresh token has not. */
+const expireStoredAccessToken = (label = 'stale_access_token') =>
+  localStorage.setItem(ACCESS_KEY, label);
+
+describe('lib/mero token handling (core#3083 single-use refresh)', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    resetMero();
+    setAppEndpointKey(NODE_URL);
+  });
+
+  afterEach(() => {
+    server.events.removeAllListeners();
+  });
+
+  describe('token store', () => {
+    it('seeds MeroJs from the app storage keys on construction', () => {
+      seedStoredSession(fixtures.tokens.admin);
+
+      expect(getMero().getTokenData()).toMatchObject({
+        access_token: fixtures.tokens.admin.access_token,
+        refresh_token: fixtures.tokens.admin.refresh_token,
+      });
+    });
+
+    it('persists a bundle handed to setTokens under the app storage keys', () => {
+      setTokens({ access_token: 'fresh_access', refresh_token: 'fresh_refresh' });
+
+      expect(localStorage.getItem(ACCESS_KEY)).toBe('fresh_access');
+      expect(localStorage.getItem(REFRESH_KEY)).toBe('fresh_refresh');
+      expect(getMero().getTokenData()).toMatchObject({ refresh_token: 'fresh_refresh' });
+    });
+
+    it('clearTokens drops both the in-memory bundle and storage', () => {
+      setTokens({ access_token: 'fresh_access', refresh_token: 'fresh_refresh' });
+
+      clearTokens();
+
+      expect(getAccessToken()).toBeNull();
+      expect(getRefreshToken()).toBeNull();
+      expect(getMero().isAuthenticated()).toBe(false);
+    });
+  });
+
+  describe('rotation', () => {
+    it('persists the refresh token mero-js rotates to, not the consumed one', async () => {
+      seedStoredSession(fixtures.tokens.admin);
+      expireStoredAccessToken();
+
+      // mero-js refreshes on the 401 `token_expired` and stores the new bundle.
+      await expect(hasLiveSession()).resolves.toBe(true);
+
+      expect(getRefreshToken()).not.toBe(fixtures.tokens.admin.refresh_token);
+      expect(getRefreshToken()).toBe('rotated_refresh_token_1');
+      expect(getAccessToken()).toBe('rotated_access_token_1');
+    });
+
+    it('does not replay a consumed refresh token after a reload', async () => {
+      seedStoredSession(fixtures.tokens.admin);
+      expireStoredAccessToken();
+
+      await expect(hasLiveSession()).resolves.toBe(true);
+      const rotated = getRefreshToken();
+
+      // The page reloads and the access token ages out again. The new MeroJs
+      // seeds itself from storage: if storage still held the CONSUMED refresh
+      // token, this second refresh would be a replay — 401 token_reuse, family
+      // revoked, hard logout.
+      reload();
+      expireStoredAccessToken('stale_access_token_2');
+
+      await expect(hasLiveSession()).resolves.toBe(true);
+      expect(getRefreshToken()).toBe('rotated_refresh_token_2');
+      expect(getRefreshToken()).not.toBe(rotated);
+    });
+  });
+
+  describe('hasLiveSession', () => {
+    it('is false with no stored tokens', async () => {
+      await expect(hasLiveSession()).resolves.toBe(false);
+    });
+
+    it('is true for a live access token, without spending a refresh token', async () => {
+      seedStoredSession(fixtures.tokens.admin);
+
+      const refreshCalls: string[] = [];
+      server.events.on('request:start', ({ request }) => {
+        if (request.url.includes('/auth/refresh')) refreshCalls.push(request.url);
+      });
+
+      await expect(hasLiveSession()).resolves.toBe(true);
+
+      // The old probe POSTed /auth/refresh on every mount, burning a
+      // single-use refresh token each time.
+      expect(refreshCalls).toEqual([]);
+      expect(getRefreshToken()).toBe(fixtures.tokens.admin.refresh_token);
+    });
+
+    it('refreshes and stays live when only the access token is stale', async () => {
+      seedStoredSession(fixtures.tokens.admin);
+      expireStoredAccessToken();
+
+      await expect(hasLiveSession()).resolves.toBe(true);
+      expect(getAccessToken()).toBe('rotated_access_token_1');
+    });
+
+    it('is false once the family is revoked by a replay', async () => {
+      seedStoredSession(fixtures.tokens.admin);
+      expireStoredAccessToken();
+      await expect(hasLiveSession()).resolves.toBe(true);
+
+      // What a client with no persistence does on the next load: present the
+      // consumed refresh token again. The node reads it as theft.
+      reload();
+      seedStoredSession(fixtures.tokens.admin);
+      expireStoredAccessToken('stale_access_token_3');
+
+      await expect(hasLiveSession()).resolves.toBe(false);
+    });
+  });
+
+  describe('isAuthRevoked', () => {
+    const httpError = (status: number, authError: string) =>
+      new HTTPError(
+        status,
+        'Unauthorized',
+        `${NODE_URL}/auth/refresh`,
+        new Headers({ 'x-auth-error': authError }),
+      );
+
+    it.each(['token_reuse', 'token_revoked'])(
+      'recognises a 401 carrying x-auth-error: %s',
+      (code) => {
+        expect(isAuthRevoked(httpError(401, code))).toBe(true);
+      },
+    );
+
+    it('recognises a 403 token_revoked', () => {
+      expect(isAuthRevoked(httpError(403, 'token_revoked'))).toBe(true);
+    });
+
+    it('recognises its own AuthRevokedError', () => {
+      expect(isAuthRevoked(new AuthRevokedError())).toBe(true);
+    });
+
+    it('leaves ordinary failures alone', () => {
+      expect(isAuthRevoked(httpError(401, 'token_expired'))).toBe(false);
+      expect(isAuthRevoked(new Error('Network request failed'))).toBe(false);
+    });
+  });
+
+  describe('generateClientKeyDirect', () => {
+    it('surfaces a revoked family as terminal and drops the session', async () => {
+      seedStoredSession(fixtures.tokens.admin);
+
+      server.use(
+        http.post('*/admin/client-key', () =>
+          HttpResponse.json(
+            { error: 'Refresh token reuse detected' },
+            { status: 401, headers: { 'x-auth-error': 'token_reuse' } },
+          ),
+        ),
+      );
+
+      await expect(
+        generateClientKeyDirect({ context_id: '', context_identity: '', permissions: ['admin'] }),
+      ).rejects.toBeInstanceOf(AuthRevokedError);
+
+      // Nothing left for a Retry button to loop on.
+      expect(getAccessToken()).toBeNull();
+      expect(getRefreshToken()).toBeNull();
+    });
+
+    it('leaves ordinary failures as plain errors, session intact', async () => {
+      seedStoredSession(fixtures.tokens.admin);
+
+      await expect(
+        generateClientKeyDirect({ context_id: '', context_identity: '', permissions: [] }),
+      ).rejects.not.toBeInstanceOf(AuthRevokedError);
+
+      expect(getAccessToken()).toBe(fixtures.tokens.admin.access_token);
+    });
+  });
+});

--- a/src/lib/mero.ts
+++ b/src/lib/mero.ts
@@ -1,12 +1,20 @@
 /**
  * Shared MeroJs instance for auth-frontend
  *
- * Token management: the auth-frontend manages tokens in its own localStorage
- * keys (calimero_access_token, calimero_refresh_token). The MeroJs instance
- * reads tokens on-demand via getAuthToken — no tokenStore, no double-storage.
+ * Token ownership: MeroJs owns the live token bundle. It is handed a
+ * TokenStore backed by the app's own localStorage keys
+ * (calimero_access_token, calimero_refresh_token), so every rotation MeroJs
+ * performs lands in the keys the rest of the app reads.
+ *
+ * This is load-bearing since calimero-network/core#3083: refresh tokens are
+ * SINGLE-USE. Every POST /auth/refresh consumes the token it is given and
+ * returns a new one; re-presenting a consumed token is treated as theft and
+ * the node revokes the whole family. So the rotated refresh token must be
+ * persisted, and nothing may ever write a stale one back over it.
  */
 
-import { MeroJs } from '@calimero-network/mero-js';
+import { HTTPError, MeroJs } from '@calimero-network/mero-js';
+import type { TokenData, TokenStore } from '@calimero-network/mero-js';
 
 const STORAGE_KEYS = {
   ACCESS_TOKEN: 'calimero_access_token',
@@ -17,30 +25,61 @@ const STORAGE_KEYS = {
 
 let meroInstance: MeroJs | null = null;
 
+/** Read `exp` (seconds) out of a JWT; fall back to an hour from now. */
+function expiresAtFromJwt(token: string): number {
+  try {
+    let b64 = token.split('.')[1];
+    b64 = b64.replace(/-/g, '+').replace(/_/g, '/');
+    while (b64.length % 4) b64 += '=';
+    const payload = JSON.parse(atob(b64));
+    if (typeof payload.exp === 'number') return payload.exp * 1000;
+  } catch {
+    /* not a JWT — use the fallback */
+  }
+  return Date.now() + 3_600_000;
+}
+
+/**
+ * TokenStore over the app's existing localStorage keys.
+ *
+ * mero-js ships a LocalStorageTokenStore, but it keeps the bundle as one JSON
+ * blob under `mero-tokens`. Adopting it would orphan every session already
+ * stored under calimero_access_token/calimero_refresh_token — and those keys
+ * are read all over the app (ManifestProcessor, useContextSelection,
+ * generateClientKeyDirect below). Keeping the keys means MeroJs's rotations
+ * are visible to every one of those readers for free.
+ */
+const tokenStore: TokenStore = {
+  getTokens(): TokenData | null {
+    const access_token = getAccessToken();
+    const refresh_token = getRefreshToken();
+    if (!access_token || !refresh_token) return null;
+
+    return {
+      access_token,
+      refresh_token,
+      expires_at: expiresAtFromJwt(access_token),
+    };
+  },
+  setTokens(data: TokenData): void {
+    localStorage.setItem(STORAGE_KEYS.ACCESS_TOKEN, data.access_token);
+    localStorage.setItem(STORAGE_KEYS.REFRESH_TOKEN, data.refresh_token);
+  },
+  clear(): void {
+    clearAccessToken();
+    clearRefreshToken();
+  },
+};
+
 export function getMero(): MeroJs {
   const baseUrl = getAppEndpointKey() || window.location.origin;
 
   if (!meroInstance) {
-    meroInstance = new MeroJs({ baseUrl });
-
-    // Seed with existing tokens if available
-    const accessToken = getAccessToken();
-    const refreshToken = getRefreshToken();
-    if (accessToken && refreshToken) {
-      let expiresAt = Date.now() + 3_600_000;
-      try {
-        let b64 = accessToken.split('.')[1];
-        b64 = b64.replace(/-/g, '+').replace(/_/g, '/');
-        while (b64.length % 4) b64 += '=';
-        const payload = JSON.parse(atob(b64));
-        if (payload.exp) expiresAt = payload.exp * 1000;
-      } catch { /* use default */ }
-      meroInstance.setTokenData({
-        access_token: accessToken,
-        refresh_token: refreshToken,
-        expires_at: expiresAt,
-      });
-    }
+    // MeroJs seeds itself from tokenStore.getTokens() in its constructor, and
+    // writes every rotation back through tokenStore.setTokens(). Constructing
+    // it without a store is what stranded rotated refresh tokens in memory
+    // while localStorage kept serving the consumed one to the next reload.
+    meroInstance = new MeroJs({ baseUrl, tokenStore });
   }
 
   return meroInstance;
@@ -52,27 +91,28 @@ export function resetMero(): void {
 
 // ---- Token helpers ----
 
-export function getAccessToken(): string | null {
-  return localStorage.getItem(STORAGE_KEYS.ACCESS_TOKEN);
+/**
+ * Hand a freshly minted bundle to MeroJs, which persists it through the token
+ * store. Always set both halves at once: writing an access token while leaving
+ * a stale refresh token behind is what gets the family revoked.
+ */
+export function setTokens(tokens: { access_token: string; refresh_token: string }): void {
+  getMero().setTokenData({
+    access_token: tokens.access_token,
+    refresh_token: tokens.refresh_token,
+    expires_at: expiresAtFromJwt(tokens.access_token),
+  });
 }
 
-export function setAccessToken(token: string): void {
-  localStorage.setItem(STORAGE_KEYS.ACCESS_TOKEN, token);
-  if (meroInstance) {
-    let expiresAt = Date.now() + 3_600_000;
-    try {
-      let b64 = token.split('.')[1];
-      b64 = b64.replace(/-/g, '+').replace(/_/g, '/');
-      while (b64.length % 4) b64 += '=';
-      const payload = JSON.parse(atob(b64));
-      if (payload.exp) expiresAt = payload.exp * 1000;
-    } catch { /* use default */ }
-    meroInstance.setTokenData({
-      access_token: token,
-      refresh_token: getRefreshToken() || '',
-      expires_at: expiresAt,
-    });
-  }
+/** Drop the session: MeroJs's in-memory bundle and both localStorage keys. */
+export function clearTokens(): void {
+  meroInstance?.clearToken();
+  clearAccessToken();
+  clearRefreshToken();
+}
+
+export function getAccessToken(): string | null {
+  return localStorage.getItem(STORAGE_KEYS.ACCESS_TOKEN);
 }
 
 export function clearAccessToken(): void {
@@ -83,12 +123,81 @@ export function getRefreshToken(): string | null {
   return localStorage.getItem(STORAGE_KEYS.REFRESH_TOKEN);
 }
 
-export function setRefreshToken(token: string): void {
-  localStorage.setItem(STORAGE_KEYS.REFRESH_TOKEN, token);
-}
-
 export function clearRefreshToken(): void {
   localStorage.removeItem(STORAGE_KEYS.REFRESH_TOKEN);
+}
+
+// ---- Session ----
+
+/** `x-auth-error` values that mean the token family is gone for good. */
+const REVOKED_AUTH_ERRORS = ['token_reuse', 'token_revoked'];
+
+/**
+ * The node revoked this token family — a retry can never succeed, only a fresh
+ * login.
+ *
+ * TODO: mero-js#67 adds a terminal `AuthRevokedError` of its own. The app is
+ * on mero-js 1.x, which does not carry it yet; once the dependency range picks
+ * up a release with it, drop this class and the header sniffing below.
+ */
+export class AuthRevokedError extends Error {
+  constructor(message = 'Your session was revoked. Please sign in again.') {
+    super(message);
+    this.name = 'AuthRevokedError';
+  }
+}
+
+/**
+ * Has the node revoked this token family?
+ *
+ * core#3083 answers a replayed (already consumed) refresh token with 401
+ * `x-auth-error: token_reuse` and kills the family; anything presented
+ * afterwards comes back as `token_revoked`. Neither is retryable, so callers
+ * must clear the tokens and go back to the provider screen rather than loop.
+ */
+export function isAuthRevoked(err: unknown): boolean {
+  if (err instanceof AuthRevokedError) return true;
+
+  if (err instanceof HTTPError && (err.status === 401 || err.status === 403)) {
+    const authError = err.headers?.get('x-auth-error');
+    if (authError && REVOKED_AUTH_ERRORS.includes(authError)) return true;
+  }
+
+  // mero-js 1.x rewraps some transport failures into a plain Error that keeps
+  // only the message, so sniff that too.
+  const message = err instanceof Error ? err.message : '';
+  return REVOKED_AUTH_ERRORS.some((code) => message.includes(code));
+}
+
+/**
+ * Is the stored session still good?
+ *
+ * Read-only: /auth/validate is a public route on the node that does nothing
+ * but verify the bearer token (core pins it as permission-free in
+ * `crates/auth/tests/client_token_contract.rs`). It consumes nothing — unlike
+ * the POST /auth/refresh this used to probe with, which now burns a
+ * single-use refresh token on every mount.
+ */
+export async function hasLiveSession(): Promise<boolean> {
+  const accessToken = getAccessToken();
+  if (!accessToken || !getRefreshToken()) return false;
+
+  const mero = getMero();
+  const { valid } = await mero.auth.validateToken(accessToken);
+  if (valid) return true;
+
+  // A 401 `token_expired` here makes mero-js refresh under the hood (rotating
+  // and persisting a fresh bundle), but it then retries with the access token
+  // we pinned into the Authorization header — the stale one — and so reports
+  // the session dead even though the refresh worked. If the bundle rotated
+  // underneath us, re-check with the token we now hold.
+  const rotated = getAccessToken();
+  if (rotated && rotated !== accessToken) {
+    const retry = await mero.auth.validateToken(rotated);
+    return retry.valid;
+  }
+
+  return false;
 }
 
 // ---- Endpoint helpers ----
@@ -135,6 +244,8 @@ export async function generateClientKeyDirect(
   request: GenerateClientKeyRequest,
 ): Promise<GenerateClientKeyResponse> {
   const baseUrl = (getAppEndpointKey() || window.location.origin).replace(/\/$/, '');
+  // Safe to read straight from storage: the token store above keeps this key in
+  // step with the bundle MeroJs holds, rotations included.
   const token = getAccessToken();
 
   const response = await fetch(`${baseUrl}/admin/client-key`, {
@@ -149,6 +260,15 @@ export async function generateClientKeyDirect(
   const json = await response.json().catch(() => null);
 
   if (!response.ok) {
+    // This fetch bypasses the SDK, so nothing else translates the node's
+    // revocation headers for us: a dead family must surface as terminal, or
+    // the flow offers a Retry button that can never succeed.
+    const authError = response.headers.get('x-auth-error');
+    if (authError && REVOKED_AUTH_ERRORS.includes(authError)) {
+      clearTokens();
+      throw new AuthRevokedError();
+    }
+
     const message = json?.error?.message ?? json?.error ?? json?.message ?? `HTTP ${response.status}`;
     throw new Error(message);
   }

--- a/src/mocks/fixtures.ts
+++ b/src/mocks/fixtures.ts
@@ -155,13 +155,6 @@ export const fixtures = {
       author: 'Test Author',
     },
   },
-  
-  challenges: {
-    near: {
-      challenge: 'mock_challenge_string_for_near_auth',
-      nonce: Buffer.from('mock_nonce_value').toString('base64'),
-    },
-  },
 };
 
 export type Fixtures = typeof fixtures;

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -32,6 +32,73 @@ export const updateScenario = (updates: Partial<typeof currentScenario>) => {
 };
 
 /**
+ * Refresh-token state machine (calimero-network/core#3083).
+ *
+ * Refresh tokens are SINGLE-USE: POST /auth/refresh consumes the token it is
+ * given and mints a new one. Re-presenting a consumed token is treated as
+ * theft — the node revokes the whole family and answers 401 with
+ * `x-auth-error: token_reuse`.
+ *
+ * The mock models this, so a client that persists the rotated token survives
+ * and one that replays a consumed token dies here exactly as it would against
+ * a real node. A static token pair (what this returned before) is precisely
+ * why CI stayed green while the app replayed consumed refresh tokens.
+ *
+ * One mock session = one token family, so a reuse revokes everything.
+ */
+let rotations = 0;
+let liveAccessTokens = new Set<string>();
+let liveRefreshTokens = new Set<string>();
+let consumedRefreshTokens = new Set<string>();
+let revokedAccessTokens = new Set<string>();
+
+const resetTokenState = () => {
+  rotations = 0;
+  // The fixture pairs stand in for an existing (logged-in) session.
+  liveAccessTokens = new Set([
+    fixtures.tokens.admin.access_token,
+    fixtures.tokens.user.access_token,
+  ]);
+  liveRefreshTokens = new Set([
+    fixtures.tokens.admin.refresh_token,
+    fixtures.tokens.user.refresh_token,
+  ]);
+  consumedRefreshTokens = new Set();
+  revokedAccessTokens = new Set();
+};
+
+resetTokenState();
+
+/** Mint a rotated pair and retire the refresh token that bought it. */
+const rotateTokens = (presentedRefreshToken: string, presentedAccessToken: string) => {
+  rotations += 1;
+  const tokens = {
+    access_token: `rotated_access_token_${rotations}`,
+    refresh_token: `rotated_refresh_token_${rotations}`,
+  };
+
+  consumedRefreshTokens.add(presentedRefreshToken);
+  liveRefreshTokens.delete(presentedRefreshToken);
+  // The access token that was traded in is superseded by the new one.
+  liveAccessTokens.delete(presentedAccessToken);
+
+  liveAccessTokens.add(tokens.access_token);
+  liveRefreshTokens.add(tokens.refresh_token);
+
+  return tokens;
+};
+
+/** Theft detected: the family dies, and everything it minted with it. */
+const revokeFamily = () => {
+  for (const token of liveAccessTokens) revokedAccessTokens.add(token);
+  liveAccessTokens.clear();
+  liveRefreshTokens.clear();
+};
+
+const bearerToken = (request: Request): string | null =>
+  request.headers.get('Authorization')?.replace(/^Bearer /, '') ?? null;
+
+/**
  * Reset scenario to default state (dev-friendly defaults)
  */
 export const resetScenario = () => {
@@ -41,6 +108,7 @@ export const resetScenario = () => {
     networkDelay: 0,
     forceErrors: [],
   };
+  resetTokenState();
 };
 
 const generateScopedToken = async (request: Request, statusOnMissingPermissions = 400) => {
@@ -90,6 +158,36 @@ const installApplicationHandler = http.post(
   installApplicationResolver,
 );
 
+const validateResolver: Parameters<typeof http.get>[1] = async ({ request }) => {
+  await delay(currentScenario.networkDelay);
+
+  const token = bearerToken(request);
+
+  if (!token) {
+    return new HttpResponse(null, {
+      status: 401,
+      headers: { 'x-auth-error': 'missing_token' },
+    });
+  }
+
+  if (revokedAccessTokens.has(token)) {
+    return new HttpResponse(null, {
+      status: 401,
+      headers: { 'x-auth-error': 'token_revoked' },
+    });
+  }
+
+  if (!liveAccessTokens.has(token)) {
+    // Stale access token — the client is expected to refresh and retry.
+    return new HttpResponse(null, {
+      status: 401,
+      headers: { 'x-auth-error': 'token_expired' },
+    });
+  }
+
+  return new HttpResponse(null, { status: 200 });
+};
+
 export const handlers = [
   // ========================================
   // Auth API Endpoints
@@ -118,31 +216,52 @@ export const handlers = [
   }),
   
   /**
-   * POST /auth/refresh - Refresh access token
+   * POST /auth/refresh - Rotate the token pair (single-use refresh tokens)
    */
   http.post('*/auth/refresh', async ({ request }) => {
     await delay(currentScenario.networkDelay);
-    
+
     const body = await request.json() as any;
-    
+
     if (currentScenario.forceErrors.includes('unauthorized')) {
       return HttpResponse.json(
-        { error: 'Invalid refresh token' }, 
+        { error: 'Invalid refresh token' },
         { status: 401 }
       );
     }
-    
+
     if (!body.access_token || !body.refresh_token) {
       return HttpResponse.json(
-        { error: 'Missing tokens' }, 
+        { error: 'Missing tokens' },
         { status: 400 }
       );
     }
-    
-    // Return refreshed tokens
-    return HttpResponse.json({ data: fixtures.tokens.user });
+
+    // Replay of an already-consumed refresh token: the node reads this as
+    // theft and burns the family down (core#3083).
+    if (consumedRefreshTokens.has(body.refresh_token)) {
+      revokeFamily();
+      return HttpResponse.json(
+        { error: 'Refresh token reuse detected' },
+        { status: 401, headers: { 'x-auth-error': 'token_reuse' } },
+      );
+    }
+
+    return HttpResponse.json({
+      data: rotateTokens(body.refresh_token, body.access_token),
+    });
   }),
-  
+
+  /**
+   * HEAD|GET /auth/validate - Read-only session gate.
+   *
+   * Public route on the node (core pins it as permission-free in
+   * `crates/auth/tests/client_token_contract.rs`): it verifies the bearer
+   * token and consumes nothing.
+   */
+  http.head(`*/auth/validate`, validateResolver),
+  http.get(`*/auth/validate`, validateResolver),
+
   /**
    * POST /auth/token - Request new token (username/password or NEAR)
    */
@@ -165,29 +284,18 @@ export const handlers = [
         return HttpResponse.json({ data: fixtures.tokens.admin });
       }
       return HttpResponse.json(
-        { error: 'Invalid credentials' }, 
+        { error: 'Invalid credentials' },
         { status: 401 }
       );
     }
-    
-    if (body.auth_method === 'near_wallet') {
-      return HttpResponse.json({ data: fixtures.tokens.user });
-    }
-    
+
+    // No wallet path: it needed GET /auth/challenge, which core#3229 removes.
     return HttpResponse.json(
-      { error: 'Unsupported auth method' }, 
+      { error: 'Unsupported auth method' },
       { status: 400 }
     );
   }),
-  
-  /**
-   * GET /auth/challenge - Get challenge for NEAR wallet auth
-   */
-  http.get(`*/auth/challenge`, async () => {
-    await delay(currentScenario.networkDelay);
-    return HttpResponse.json({ data: fixtures.challenges.near });
-  }),
-  
+
   /**
    * POST /admin/client-key - Generate scoped token
    */

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -6,6 +6,24 @@ import { beforeAll, afterEach, afterAll, vi } from 'vitest';
 import { setupServer } from 'msw/node';
 import { handlers, resetScenario } from './src/mocks/handlers';
 
+/**
+ * Drop request-timeout signals in tests.
+ *
+ * This environment mixes jsdom's AbortController/AbortSignal with Node's fetch
+ * (undici), whose Request brand-checks `init.signal` and rejects anything that
+ * did not come from its own realm — including a signal round-tripped straight
+ * back out of `new Request()`:
+ *
+ *   RequestInit: Expected signal ("AbortSignal {}") to be an instance of AbortSignal
+ *
+ * Nothing constructible here passes that check, so any mero-js call (which
+ * attaches a 10s timeout signal) dies as a "network error" before MSW ever sees
+ * it. mero-js filters falsy signals out of combineSignals(), so returning
+ * undefined simply runs the SDK's requests without a timeout — under test only.
+ * Browsers and Tauri share one realm and are unaffected.
+ */
+AbortSignal.timeout = (() => undefined) as unknown as typeof AbortSignal.timeout;
+
 // Create MSW server with handlers
 export const server = setupServer(...handlers);
 


### PR DESCRIPTION
## Why

[calimero-network/core#3083](https://github.com/calimero-network/core/pull/3083) makes refresh tokens **single-use**: every `POST /auth/refresh` consumes the token it is given and returns a new one. Re-presenting a consumed token is read as theft — the node revokes the **whole family** and answers `401` with `x-auth-error: token_reuse`.

The auth frontend breaks on all three counts today:

1. **`new MeroJs({ baseUrl })` had no `tokenStore`.** mero-js persists a rotated bundle via `this.tokenStore?.setTokens(...)` — with no store that is a **no-op**. The rotated refresh token lived only in memory while `localStorage` kept the **consumed** one. Any reload re-seeded MeroJs from the stale value → next refresh is a replay → family revoked → hard logout.
2. **`setAccessToken()` re-injected the OLD refresh token** over the live in-memory one (`setTokenData({ access_token, refresh_token: getRefreshToken() || '' })`), and callers ran it *before* persisting the new one.
3. **The mount-time liveness probe was `POST /auth/refresh`** — it burned a single-use refresh token on *every mount*, and never even worked as a check (the node rejects refresh while the access token is still valid, which is why the code was string-matching `'Access token still valid'`).

Plus: the mock returned a **static** token pair from `/auth/refresh` and never rotated — which is precisely why CI stayed green through all of this.

## Before → After

| | Before | After |
|---|---|---|
| Rotated refresh token | Lost (no `tokenStore` → `setTokens` is a no-op); `localStorage` keeps the consumed one | Persisted through a `TokenStore` over the app's existing `calimero_access_token` / `calimero_refresh_token` keys |
| Page reload | Re-seeds MeroJs from the **consumed** token → replay → `token_reuse` → family revoked | Seeds from the **rotated** token → refresh succeeds |
| `setAccessToken()` | Writes a stale refresh token over the live one | Removed. `setTokens()` writes both halves at once; MeroJs is the single owner |
| Session probe on mount | `POST /auth/refresh` — spends a single-use token every mount | `HEAD /auth/validate` — read-only, consumes nothing |
| Revoked family | Error view with a Retry button that can never succeed | Terminal: clear tokens, back to the provider screen |
| `GET /auth/challenge` / `near_wallet` | Dead code + mocks (no wallet provider; route removed) | Gone |
| Mock `/auth/refresh` | Static pair, never rotates | Rotates every call; `401 token_reuse` on replay; revokes the family |

**Storage keys are unchanged on purpose.** mero-js ships a `LocalStorageTokenStore`, but it keeps the bundle as one JSON blob under `mero-tokens` — adopting it would orphan every existing session. The adapter keeps the app's keys, so `ManifestProcessor`, `useContextSelection` and `generateClientKeyDirect` keep reading the live bundle for free.

### Key changes
- `src/lib/mero.ts` — `TokenStore` adapter over the existing keys; `setTokens()` / `clearTokens()`; `hasLiveSession()` (read-only probe); `isAuthRevoked()` + `AuthRevokedError`; `setAccessToken`/`setRefreshToken` deleted.
- `src/components/auth/EnsureAdminSession.tsx` — refresh probe → `hasLiveSession()`.
- `src/components/auth/LoginView.tsx` — same probe fix (it had the identical bug in `checkIfTokenIsValid`), dead wallet path removed, revoked family routes back to login.
- `src/mocks/handlers.ts` — real rotation state machine + `/auth/validate` gate.

## How to test

```bash
npm install --legacy-peer-deps
npx vitest run        # 78 passed (58 before)
npm run build         # tsc && vite build

# browser e2e against a live merod (same as the ui-e2e CI job)
merod --home ./ui-node --node ui init --auth-mode embedded --server-port 4081 --swarm-port 4082
sed -i '' 's/allow_all_origins = false/allow_all_origins = true/' ./ui-node/ui/config.toml
merod --home ./ui-node --node ui run &
NODE_URL=http://localhost:4081 npx playwright test   # 2 passed
```

New tests (**6 of them fail against the old `lib/mero.ts`** — verified by reverting the `tokenStore`):

- `src/lib/__tests__/mero.test.ts`
  - `rotation > persists the refresh token mero-js rotates to, not the consumed one`
  - `rotation > does not replay a consumed refresh token after a reload`
  - `hasLiveSession > is true for a live access token, without spending a refresh token`
  - `hasLiveSession > refreshes and stays live when only the access token is stale`
  - `hasLiveSession > is false once the family is revoked by a replay`
  - `token store > seeds MeroJs from the app storage keys on construction`
  - `isAuthRevoked > ...`, `generateClientKeyDirect > surfaces a revoked family as terminal and drops the session`
- `src/__tests__/mocks.test.ts`
  - `should rotate the refresh token on every refresh`
  - `should reject a replayed refresh token with x-auth-error: token_reuse`
  - `should revoke the whole family once a replay is detected`
  - `should mock the read-only /auth/validate session gate`
- `e2e/live-login.spec.ts`
  - `a returning user resumes the session without spending a refresh token` — against a **live merod**: asserts no `POST /auth/refresh` fires on remount and the stored refresh token is unchanged.

## Notes for the reviewer

- **`vitest.setup.ts` shims `AbortSignal.timeout`.** This env mixes jsdom's `AbortSignal` with Node's `fetch` (undici), whose `Request` brand-checks `init.signal` and rejects anything from another realm — *including a signal round-tripped straight out of `new Request()`*. Nothing constructible here passes, so every mero-js call died as a "network error" before MSW ever saw it. That is why **no test in this repo has ever exercised an SDK call** — a third reason these bugs survived CI. Browsers and Tauri share one realm and are unaffected.
- **The app is on `mero-js ^1.2.1` (resolves to 1.4.1); mero-js is at 7.0.0.** So the `AuthRevokedError` from mero-js#67 is not reachable from this dependency range: revocation is detected via the `x-auth-error` header, with a `TODO` to switch over once the range picks up a release carrying it. Bumping across six majors is out of scope here.
- The `@near-wallet-selector/*` and `near-api-js` deps are now unimported (they were lazily loaded, so the bundle is unchanged at 803 kB). Left in `package.json` for a follow-up.

## Depends on

- calimero-network/core#3083 (single-use refresh tokens) — the behaviour this fixes.
- calimero-network/core#3229 (removes `GET /auth/challenge`) — the dead path removed here.
- calimero-network/mero-js#67 (rotation-safe refresh: single-flight, cross-tab lock, `AuthRevokedError`) — complementary, and required before the header sniffing can be dropped. Not consumable until this app moves off mero-js 1.x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)