### PR TITLE
fix(auth): allowlist the SSO callback-url to stop token exfiltration (H2)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,18 @@ jobs:
   ui-e2e:
     name: Browser e2e against live merod
     runs-on: ubuntu-latest
+    env:
+      # core >= 0.11.0-rc.14 gates the FIRST root-key bootstrap behind an
+      # out-of-band secret (calimero-network/core#3221) and enforces an 8-char
+      # minimum password at creation (#3081). The merod process below inherits
+      # this env, so its embedded auth accepts the same secret; the "Bootstrap
+      # root key" step then pre-provisions the user so the UI login is a plain
+      # existing-user authentication. CI-only value for an ephemeral node.
+      MERO_AUTH_BOOTSTRAP_SECRET: ui-e2e-ci-bootstrap
+      # Credentials the Playwright spec logs in with (live-login.spec.ts reads
+      # MERO_E2E_USER / MERO_E2E_PASS). Password must satisfy the min length.
+      MERO_E2E_USER: dev
+      MERO_E2E_PASS: dev-password
     steps:
       - uses: actions/checkout@v4
 
@@ -75,6 +87,23 @@ jobs:
           done
           echo "node never became healthy" >&2
           exit 1
+
+      - name: Bootstrap root key (out-of-band secret)
+        # rc.14 disables trust-on-first-use: mint the root key here presenting
+        # MERO_AUTH_BOOTSTRAP_SECRET so the UI's dev/dev-password login is a plain
+        # existing-user auth (the UI form has no bootstrap-secret field).
+        run: |
+          BODY=$(jq -n --arg u "$MERO_E2E_USER" --arg p "$MERO_E2E_PASS" \
+            --arg s "$MERO_AUTH_BOOTSTRAP_SECRET" --argjson ts "$(date +%s)" \
+            '{auth_method: "user_password", public_key: $u,
+              client_name: "ui-e2e", permissions: ["admin"], timestamp: $ts,
+              provider_data: {username: $u, password: $p, bootstrap_secret: $s}}')
+          RESP=$(curl -fsS -m 10 -X POST http://localhost:4081/auth/token \
+            -H 'Content-Type: application/json' -d "$BODY") || {
+              echo "::error::root-key bootstrap request failed"; exit 1; }
+          echo "$RESP" | jq -e '.data.access_token // empty' > /dev/null || {
+            echo "::error::bootstrap did not return a token: $RESP"; exit 1; }
+          echo "root key bootstrapped for $MERO_E2E_USER"
 
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium

--- a/src/components/auth/LoginView.tsx
+++ b/src/components/auth/LoginView.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useCallback, useEffect } from 'react';
 import ProviderSelector from '../providers/ProviderSelector';
 import { handleUrlParams, getStoredUrlParam, clearStoredUrlParams } from '../../utils/urlParams';
+import { resolveSafeCallbackUrl } from '../../utils/callbackUrl';
 import {
   getMero,
   generateClientKeyDirect,
@@ -277,9 +278,17 @@ const LoginView: React.FC = () => {
       });
 
       if (response.access_token && response.refresh_token) {
-        const callback = getStoredUrlParam('callback-url');
-        if (callback) {
-          const returnUrl = new URL(callback);
+        const rawCallback = getStoredUrlParam('callback-url');
+        const returnUrl = resolveSafeCallbackUrl(rawCallback);
+        if (rawCallback && !returnUrl) {
+          // Refuse to redirect the minted token pair to an unvalidated / untrusted
+          // callback origin (open-redirect token exfiltration). Fail closed:
+          // the tokens are never handed out; the user sees an error instead.
+          clearStoredUrlParams();
+          setError('Login callback destination is not allowed.');
+          return;
+        }
+        if (returnUrl) {
           const fragmentParams = new URLSearchParams();
           fragmentParams.set('access_token', response.access_token);
           fragmentParams.set('refresh_token', response.refresh_token);
@@ -358,9 +367,17 @@ const LoginView: React.FC = () => {
       });
 
       if (response.access_token && response.refresh_token) {
-        const callback = getStoredUrlParam('callback-url');
-        if (callback) {
-          const returnUrl = new URL(callback);
+        const rawCallback = getStoredUrlParam('callback-url');
+        const returnUrl = resolveSafeCallbackUrl(rawCallback);
+        if (rawCallback && !returnUrl) {
+          // Refuse to redirect the minted token pair to an unvalidated / untrusted
+          // callback origin (open-redirect token exfiltration). Fail closed:
+          // the tokens are never handed out; the user sees an error instead.
+          clearStoredUrlParams();
+          setError('Login callback destination is not allowed.');
+          return;
+        }
+        if (returnUrl) {
           const fragmentParams = new URLSearchParams();
           fragmentParams.set('access_token', response.access_token);
           fragmentParams.set('refresh_token', response.refresh_token);

--- a/src/components/auth/LoginView.tsx
+++ b/src/components/auth/LoginView.tsx
@@ -1,11 +1,10 @@
 import React, { useState, useCallback, useEffect } from 'react';
 import ProviderSelector from '../providers/ProviderSelector';
-import { handleUrlParams, getStoredUrlParam, clearStoredUrlParams } from '../../utils/urlParams';
-import { resolveSafeCallbackUrl } from '../../utils/callbackUrl';
+import { handleUrlParams, getStoredUrlParam } from '../../utils/urlParams';
+import { resolveSafeCallbackUrl, redirectTokensToCallback } from '../../utils/callbackUrl';
 import {
   getMero,
   generateClientKeyDirect,
-  getAppEndpointKey,
   hasLiveSession,
   isAuthRevoked,
   setTokens,
@@ -278,36 +277,17 @@ const LoginView: React.FC = () => {
       });
 
       if (response.access_token && response.refresh_token) {
-        const rawCallback = getStoredUrlParam('callback-url');
-        const returnUrl = resolveSafeCallbackUrl(rawCallback);
-        if (rawCallback && !returnUrl) {
-          // Refuse to redirect the minted token pair to an unvalidated / untrusted
-          // callback origin (open-redirect token exfiltration). Fail closed:
-          // the tokens are never handed out; the user sees an error instead.
-          clearStoredUrlParams();
-          setError('Login callback destination is not allowed.');
+        const callback = getStoredUrlParam('callback-url');
+        const outcome = redirectTokensToCallback(callback, response, {
+          application_id: localStorage.getItem('installed-application-id'),
+        });
+        if (outcome !== 'ok') {
+          setError(
+            outcome === 'missing'
+              ? 'Missing callback URL'
+              : 'Login callback destination is not allowed.',
+          );
           return;
-        }
-        if (returnUrl) {
-          const fragmentParams = new URLSearchParams();
-          fragmentParams.set('access_token', response.access_token);
-          fragmentParams.set('refresh_token', response.refresh_token);
-
-          // Include node URL so CalimeroProvider can set appEndpointKey
-          const nodeUrl = getStoredUrlParam('app-url') || getAppEndpointKey();
-          if (nodeUrl) {
-            fragmentParams.set('node_url', nodeUrl);
-          }
-
-          // Include applicationId for package-based flows
-          const installedAppId = localStorage.getItem('installed-application-id');
-          if (installedAppId) {
-            fragmentParams.set('application_id', installedAppId);
-          }
-
-          clearStoredUrlParams();
-          // Combine the base URL with the fragment
-          window.location.href = `${returnUrl.toString()}#${fragmentParams.toString()}`;
         }
       } else {
         throw new Error('Failed to generate client key');
@@ -367,43 +347,21 @@ const LoginView: React.FC = () => {
       });
 
       if (response.access_token && response.refresh_token) {
-        const rawCallback = getStoredUrlParam('callback-url');
-        const returnUrl = resolveSafeCallbackUrl(rawCallback);
-        if (rawCallback && !returnUrl) {
-          // Refuse to redirect the minted token pair to an unvalidated / untrusted
-          // callback origin (open-redirect token exfiltration). Fail closed:
-          // the tokens are never handed out; the user sees an error instead.
-          clearStoredUrlParams();
-          setError('Login callback destination is not allowed.');
+        const callback = getStoredUrlParam('callback-url');
+        // Capture the app id before the shared handoff clears/redirects.
+        const installedAppIdForRedirect = localStorage.getItem('installed-application-id');
+        if (!resolveSafeCallbackUrl(callback)) {
+          setError(
+            callback
+              ? 'Login callback destination is not allowed.'
+              : 'Missing callback URL',
+          );
           return;
         }
-        if (returnUrl) {
-          const fragmentParams = new URLSearchParams();
-          fragmentParams.set('access_token', response.access_token);
-          fragmentParams.set('refresh_token', response.refresh_token);
-
-          // Include node URL so CalimeroProvider can set appEndpointKey
-          const nodeUrl = getStoredUrlParam('app-url') || getAppEndpointKey();
-          if (nodeUrl) {
-            fragmentParams.set('node_url', nodeUrl);
-          }
-
-          // Include applicationId for package-based flows (before cleanup!)
-          const installedAppIdForRedirect = localStorage.getItem('installed-application-id');
-          if (installedAppIdForRedirect) {
-            fragmentParams.set('application_id', installedAppIdForRedirect);
-          } else {
-            console.warn('❌ DEBUG: No installed-application-id in localStorage!');
-          }
-          
-          
-          // Clean up stored application ID
-          localStorage.removeItem('installed-application-id');
-          
-          clearStoredUrlParams();
-          // Combine the base URL with the fragment
-          window.location.href = `${returnUrl.toString()}#${fragmentParams.toString()}`;
-        }
+        localStorage.removeItem('installed-application-id');
+        redirectTokensToCallback(callback, response, {
+          application_id: installedAppIdForRedirect,
+        });
       } else {
         throw new Error('Failed to generate client key');
       }

--- a/src/flows/AdminFlow.tsx
+++ b/src/flows/AdminFlow.tsx
@@ -1,9 +1,10 @@
 import React, { useMemo, useState } from 'react';
-import { generateClientKeyDirect, getAppEndpointKey } from '../lib/mero';
+import { generateClientKeyDirect } from '../lib/mero';
 import { PermissionsView } from '../components/permissions/PermissionsView';
 import { ErrorView } from '../components/common/ErrorView';
 import Loader from '../components/common/Loader';
-import { clearStoredUrlParams, getStoredUrlParam } from '../utils/urlParams';
+import { getStoredUrlParam } from '../utils/urlParams';
+import { redirectTokensToCallback } from '../utils/callbackUrl';
 import { normalizePermissions } from '../utils/permissions';
 
 /**
@@ -35,23 +36,16 @@ export const AdminFlow: React.FC = () => {
 
       if (response.access_token && response.refresh_token) {
         const callback = getStoredUrlParam('callback-url');
-        if (!callback) {
-          setError('Missing callback URL');
+        const outcome = redirectTokensToCallback(callback, response);
+        if (outcome !== 'ok') {
+          setError(
+            outcome === 'missing'
+              ? 'Missing callback URL'
+              : 'Login callback destination is not allowed.',
+          );
           setGenerating(false);
           return;
         }
-
-        const returnUrl = new URL(callback);
-        const fragmentParams = new URLSearchParams();
-        fragmentParams.set('access_token', response.access_token);
-        fragmentParams.set('refresh_token', response.refresh_token);
-        // Callback contract (mero-react binds its client to this): the node
-        // that issued the tokens, which is NOT this page's origin when the
-        // UI is served separately from the node (app-url param).
-        fragmentParams.set('node_url', getAppEndpointKey() || window.location.origin);
-
-        clearStoredUrlParams();
-        window.location.href = `${returnUrl.toString()}#${fragmentParams.toString()}`;
       } else {
         throw new Error('Failed to generate client key');
       }

--- a/src/flows/ApplicationFlow.tsx
+++ b/src/flows/ApplicationFlow.tsx
@@ -1,12 +1,13 @@
 import React, { useMemo, useState } from 'react';
-import { generateClientKeyDirect, getAppEndpointKey } from '../lib/mero';
+import { generateClientKeyDirect } from '../lib/mero';
+import { redirectTokensToCallback } from '../utils/callbackUrl';
 import { ApplicationInstallCheck } from '../components/applications/ApplicationInstallCheck';
 import { PermissionsView } from '../components/permissions/PermissionsView';
 import { ContextSelector } from '../components/context/ContextSelector';
 import { ErrorView } from '../components/common/ErrorView';
 import Loader from '../components/common/Loader';
 import { AppMode } from '../types/flows';
-import { clearStoredUrlParams, getStoredUrlParam } from '../utils/urlParams';
+import { getStoredUrlParam } from '../utils/urlParams';
 import { normalizePermissions } from '../utils/permissions';
 
 interface ApplicationFlowProps {
@@ -64,28 +65,19 @@ export const ApplicationFlow: React.FC<ApplicationFlowProps> = ({
 
       if (response.access_token && response.refresh_token) {
         const callback = getStoredUrlParam('callback-url');
-        if (!callback) {
-          setError('Missing callback URL');
+        const outcome = redirectTokensToCallback(callback, response, {
+          context_id: contextId,
+          context_identity: identity,
+        });
+        if (outcome !== 'ok') {
+          setError(
+            outcome === 'missing'
+              ? 'Missing callback URL'
+              : 'Login callback destination is not allowed.',
+          );
           setGenerating(false);
           return;
         }
-
-        const returnUrl = new URL(callback);
-        const fragmentParams = new URLSearchParams();
-        fragmentParams.set('access_token', response.access_token);
-        fragmentParams.set('refresh_token', response.refresh_token);
-
-        if (contextId) {
-          fragmentParams.set('context_id', contextId);
-        }
-        if (identity) {
-          fragmentParams.set('context_identity', identity);
-        }
-
-        fragmentParams.set('node_url', getAppEndpointKey() || window.location.origin);
-
-        clearStoredUrlParams();
-        window.location.href = `${returnUrl.toString()}#${fragmentParams.toString()}`;
       } else {
         throw new Error('Failed to generate client key');
       }

--- a/src/flows/PackageFlow.tsx
+++ b/src/flows/PackageFlow.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useState } from 'react';
-import { generateClientKeyDirect, getAppEndpointKey } from '../lib/mero';
+import { generateClientKeyDirect } from '../lib/mero';
+import { resolveSafeCallbackUrl, redirectTokensToCallback } from '../utils/callbackUrl';
 import { ManifestProcessor } from '../components/manifest/ManifestProcessor';
 import { PermissionsView } from '../components/permissions/PermissionsView';
 import { ContextSelector } from '../components/context/ContextSelector';
@@ -7,7 +8,7 @@ import { ErrorView } from '../components/common/ErrorView';
 import Loader from '../components/common/Loader';
 import { PageShell } from '../components/common/PageShell';
 import { AppMode } from '../types/flows';
-import { clearStoredUrlParams, getStoredUrlParam } from '../utils/urlParams';
+import { getStoredUrlParam } from '../utils/urlParams';
 import { normalizePermissions } from '../utils/permissions';
 import {
   Button,
@@ -107,34 +108,26 @@ export const PackageFlow: React.FC<PackageFlowProps> = ({
 
       if (response.access_token && response.refresh_token) {
         const callback = getStoredUrlParam('callback-url');
-        if (!callback) {
-          setError('Missing callback URL');
+        // Validate the callback BEFORE the package-flow cleanup + redirect, so a
+        // missing/untrusted callback hands out no tokens and leaves state intact.
+        if (!resolveSafeCallbackUrl(callback)) {
+          setError(
+            callback
+              ? 'Login callback destination is not allowed.'
+              : 'Missing callback URL',
+          );
           setGenerating(false);
           return;
         }
 
-        const returnUrl = new URL(callback);
-        const fragmentParams = new URLSearchParams();
-        fragmentParams.set('access_token', response.access_token);
-        fragmentParams.set('refresh_token', response.refresh_token);
-
-        if (installedAppId) {
-          fragmentParams.set('application_id', installedAppId);
-        }
-        if (contextId) {
-          fragmentParams.set('context_id', contextId);
-        }
-        if (identity) {
-          fragmentParams.set('context_identity', identity);
-        }
-
-        fragmentParams.set('node_url', getAppEndpointKey() || window.location.origin);
-
         sessionStorage.removeItem('installed-application-id');
         localStorage.removeItem('installed-application-id');
         localStorage.removeItem('manifest-info');
-        clearStoredUrlParams();
-        window.location.href = `${returnUrl.toString()}#${fragmentParams.toString()}`;
+        redirectTokensToCallback(callback, response, {
+          application_id: installedAppId,
+          context_id: contextId,
+          context_identity: identity,
+        });
       } else {
         throw new Error('Failed to generate client key');
       }

--- a/src/utils/__tests__/callbackUrl.test.ts
+++ b/src/utils/__tests__/callbackUrl.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { resolveSafeCallbackUrl } from '../callbackUrl';
+
+describe('resolveSafeCallbackUrl', () => {
+  it('rejects a missing / empty callback', () => {
+    expect(resolveSafeCallbackUrl(null)).toBeNull();
+    expect(resolveSafeCallbackUrl(undefined)).toBeNull();
+    expect(resolveSafeCallbackUrl('')).toBeNull();
+  });
+
+  it('rejects a malformed URL', () => {
+    expect(resolveSafeCallbackUrl('not a url')).toBeNull();
+    expect(resolveSafeCallbackUrl('/relative/path')).toBeNull();
+  });
+
+  it('rejects non-http(s) schemes (XSS via callback)', () => {
+    expect(resolveSafeCallbackUrl('javascript:alert(1)')).toBeNull();
+    expect(
+      resolveSafeCallbackUrl('data:text/html,<script>alert(1)</script>'),
+    ).toBeNull();
+    expect(resolveSafeCallbackUrl('file:///etc/passwd')).toBeNull();
+  });
+
+  it('rejects an arbitrary foreign origin (the token-exfil case)', () => {
+    expect(resolveSafeCallbackUrl('https://evil.example/#')).toBeNull();
+    expect(resolveSafeCallbackUrl('http://attacker.test/cb')).toBeNull();
+  });
+
+  it('allows loopback on any port and path', () => {
+    for (const u of [
+      'http://localhost:5173/',
+      'http://localhost:2428/auth/callback',
+      'http://127.0.0.1:3000/x',
+      'http://sub.localhost:9000/y',
+    ]) {
+      const r = resolveSafeCallbackUrl(u);
+      expect(r, u).not.toBeNull();
+      expect(r!.toString()).toBe(new URL(u).toString());
+    }
+  });
+
+  it('allows the auth-frontend own origin (same-origin)', () => {
+    const sameOrigin = `${window.location.origin}/callback`;
+    expect(resolveSafeCallbackUrl(sameOrigin)).not.toBeNull();
+  });
+
+  it('does not treat a look-alike host as loopback', () => {
+    // localhost.evil.example must NOT be accepted as loopback.
+    expect(resolveSafeCallbackUrl('https://localhost.evil.example/cb')).toBeNull();
+    expect(resolveSafeCallbackUrl('https://notlocalhost/cb')).toBeNull();
+  });
+});

--- a/src/utils/__tests__/callbackUrl.test.ts
+++ b/src/utils/__tests__/callbackUrl.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { resolveSafeCallbackUrl } from '../callbackUrl';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { resolveSafeCallbackUrl, redirectTokensToCallback } from '../callbackUrl';
 
 describe('resolveSafeCallbackUrl', () => {
   it('rejects a missing / empty callback', () => {
@@ -48,5 +48,64 @@ describe('resolveSafeCallbackUrl', () => {
     // localhost.evil.example must NOT be accepted as loopback.
     expect(resolveSafeCallbackUrl('https://localhost.evil.example/cb')).toBeNull();
     expect(resolveSafeCallbackUrl('https://notlocalhost/cb')).toBeNull();
+  });
+});
+
+describe('redirectTokensToCallback', () => {
+  const tokens = { access_token: 'AT', refresh_token: 'RT' };
+  let href: string;
+  let realDescriptor: PropertyDescriptor | undefined;
+
+  beforeEach(() => {
+    href = window.location.href;
+    realDescriptor = Object.getOwnPropertyDescriptor(window.location, 'href');
+    Object.defineProperty(window.location, 'href', {
+      configurable: true,
+      get: () => href,
+      set: (v: string) => {
+        href = v;
+      },
+    });
+  });
+
+  afterEach(() => {
+    if (realDescriptor) {
+      Object.defineProperty(window.location, 'href', realDescriptor);
+    }
+    vi.restoreAllMocks();
+  });
+
+  it('returns "missing" and does not navigate when no callback is given', () => {
+    const before = window.location.href;
+    expect(redirectTokensToCallback(null, tokens)).toBe('missing');
+    expect(window.location.href).toBe(before);
+  });
+
+  it('returns "untrusted" and does not navigate for a foreign origin', () => {
+    const before = window.location.href;
+    expect(redirectTokensToCallback('https://evil.example/cb', tokens)).toBe(
+      'untrusted',
+    );
+    // The token pair must never reach an untrusted origin.
+    expect(window.location.href).toBe(before);
+  });
+
+  it('redirects the token pair in the fragment for a trusted loopback callback', () => {
+    const outcome = redirectTokensToCallback(
+      'http://localhost:5173/cb',
+      tokens,
+      { context_id: 'CTX', context_identity: null },
+    );
+    expect(outcome).toBe('ok');
+    expect(window.location.href.startsWith('http://localhost:5173/cb#')).toBe(
+      true,
+    );
+    const params = new URLSearchParams(window.location.href.split('#')[1]);
+    expect(params.get('access_token')).toBe('AT');
+    expect(params.get('refresh_token')).toBe('RT');
+    expect(params.get('context_id')).toBe('CTX');
+    // null / empty extras are skipped, not serialized as "null".
+    expect(params.has('context_identity')).toBe(false);
+    expect(params.get('node_url')).toBeTruthy();
   });
 });

--- a/src/utils/callbackUrl.ts
+++ b/src/utils/callbackUrl.ts
@@ -1,3 +1,6 @@
+import { clearStoredUrlParams } from './urlParams';
+import { getAppEndpointKey } from '../lib/mero';
+
 // Allowlist validation for the SSO `callback-url`.
 //
 // After a successful login the auth frontend redirects the freshly-minted
@@ -84,4 +87,45 @@ export function resolveSafeCallbackUrl(raw: string | null | undefined): URL | nu
   if (allowedOrigins().has(url.origin)) return url;
 
   return null;
+}
+
+/**
+ * Validate `rawCallback` and, only if it is trusted, hand the minted token pair
+ * (plus `extra` fragment params and the issuing `node_url`) to it by navigating
+ * the browser to `<callback>#access_token=…&refresh_token=…`.
+ *
+ * This is the single, shared token-handoff path for every auth flow — it is the
+ * security boundary that stops an attacker-supplied `callback-url` from
+ * exfiltrating the tokens to an arbitrary origin. Callers must funnel through it
+ * rather than building the redirect inline.
+ *
+ * @returns `'ok'` after redirecting, `'missing'` when no callback was provided,
+ *   or `'untrusted'` when the callback failed validation. In the non-`'ok'`
+ *   cases the tokens are NOT handed out and no navigation happens; the caller
+ *   should surface an error.
+ */
+export function redirectTokensToCallback(
+  rawCallback: string | null | undefined,
+  tokens: { access_token: string; refresh_token: string },
+  extra: Record<string, string | null | undefined> = {},
+): 'ok' | 'missing' | 'untrusted' {
+  if (!rawCallback) return 'missing';
+
+  const returnUrl = resolveSafeCallbackUrl(rawCallback);
+  if (!returnUrl) return 'untrusted';
+
+  const fragmentParams = new URLSearchParams();
+  fragmentParams.set('access_token', tokens.access_token);
+  fragmentParams.set('refresh_token', tokens.refresh_token);
+  for (const [key, value] of Object.entries(extra)) {
+    if (value) fragmentParams.set(key, value);
+  }
+  // Callback contract (mero-react binds its client to this): the node that
+  // issued the tokens, which is NOT this page's origin when the UI is served
+  // separately from the node (app-url param).
+  fragmentParams.set('node_url', getAppEndpointKey() || window.location.origin);
+
+  clearStoredUrlParams();
+  window.location.href = `${returnUrl.toString()}#${fragmentParams.toString()}`;
+  return 'ok';
 }

--- a/src/utils/callbackUrl.ts
+++ b/src/utils/callbackUrl.ts
@@ -1,0 +1,87 @@
+// Allowlist validation for the SSO `callback-url`.
+//
+// After a successful login the auth frontend redirects the freshly-minted
+// access + refresh token pair into `callback-url`'s fragment. If that URL is
+// taken from the request unvalidated, an attacker who lures a logged-in user to
+//   http://<node>/auth/...?callback-url=https://evil.example&permissions=admin
+// and gets them to approve the consent screen exfiltrates a working token pair
+// to an arbitrary origin (the classic OAuth open-redirect token-leak). This
+// module gates the redirect so tokens can only ever be handed to a trusted
+// origin.
+//
+// Trust policy (least surprise, non-breaking for local/desktop):
+//   * scheme must be http/https — blocks `javascript:`, `data:`, `file:` …
+//   * loopback hosts are always allowed (local dev, the node itself, and
+//     desktop app windows served from localhost)
+//   * the auth frontend's own origin (the node) is always allowed
+//   * any additional deployed app origins must be explicitly allowlisted via
+//     the `VITE_ALLOWED_CALLBACK_ORIGINS` build/env var (comma-separated), e.g.
+//     "https://app.example.com,https://chat.example.com"
+//   * everything else is rejected — the caller must NOT redirect the tokens.
+
+const isLoopbackHost = (host: string): boolean => {
+  const h = host.toLowerCase();
+  return (
+    h === 'localhost' ||
+    h === '127.0.0.1' ||
+    h === '::1' ||
+    h === '[::1]' ||
+    h.endsWith('.localhost')
+  );
+};
+
+const allowedOrigins = (): Set<string> => {
+  const origins = new Set<string>();
+
+  // Same-origin as the auth frontend (the node) is always trusted.
+  try {
+    origins.add(window.location.origin);
+  } catch {
+    /* no window origin (non-browser) — nothing to add */
+  }
+
+  // Operator-configured trusted app origins for apps served from a different
+  // origin than the node (e.g. a hosted frontend). Malformed entries are ignored.
+  const configured = import.meta.env.VITE_ALLOWED_CALLBACK_ORIGINS as
+    | string
+    | undefined;
+  if (configured) {
+    for (const raw of configured.split(',')) {
+      const trimmed = raw.trim();
+      if (!trimmed) continue;
+      try {
+        origins.add(new URL(trimmed).origin);
+      } catch {
+        /* ignore a malformed allowlist entry rather than failing closed on all */
+      }
+    }
+  }
+
+  return origins;
+};
+
+/**
+ * Parse and validate a `callback-url` against the trust policy above.
+ *
+ * @returns the parsed `URL` when the callback is trusted, or `null` when it is
+ *   missing, malformed, uses a non-http(s) scheme, or points at an untrusted
+ *   origin. On `null`, the caller MUST NOT redirect the token pair.
+ */
+export function resolveSafeCallbackUrl(raw: string | null | undefined): URL | null {
+  if (!raw) return null;
+
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    return null;
+  }
+
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') return null;
+
+  if (isLoopbackHost(url.hostname)) return url;
+
+  if (allowedOrigins().has(url.origin)) return url;
+
+  return null;
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -11,6 +11,13 @@ declare module '*.svg?url' {
 
 interface ImportMetaEnv {
   readonly VITE_REGISTRY_URL?: string;
+  /**
+   * Comma-separated list of trusted origins the SSO `callback-url` may point at,
+   * in addition to loopback and the auth frontend's own origin. Set this to the
+   * origins of apps served from a different host than the node
+   * (e.g. "https://app.example.com,https://chat.example.com"). See callbackUrl.ts.
+   */
+  readonly VITE_ALLOWED_CALLBACK_ORIGINS?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Vulnerability (HIGH)

The login flow redirected the freshly-minted **access + refresh token pair** into `callback-url`'s fragment with **zero validation**:

\`\`\`ts
const returnUrl = new URL(callback);            // any scheme, any origin
fragmentParams.set('access_token', response.access_token);
fragmentParams.set('refresh_token', response.refresh_token);
window.location.href = \`\${returnUrl}#\${fragmentParams}\`;
\`\`\`

**Attack:** a malicious web page navigates a logged-in user (top-level navigation, so CORS doesn't block it — and `localhost:2428` is a guessable, reachable target) to their own node's auth page:

\`\`\`
http://localhost:2428/auth/...?callback-url=https://evil.example&permissions=admin&app-url=...
\`\`\`

The user has a live root session (`hasLiveSession()` auto-continues, no password re-entry), approves the standard consent screen, and an **admin-scoped** token pair lands in `https://evil.example/#access_token=…&refresh_token=…`. This is the classic OAuth **open-redirect token leak**. Single-use refresh does **not** mitigate it — the attacker is handed a live, valid pair (they can rotate it to keep the family alive). Same class as core finding #6 (fixed in core's demo handler); this is the *producer* side, unfixed.

## Fix

New `src/utils/callbackUrl.ts` → `resolveSafeCallbackUrl()` gates the redirect:
- **http/https only** — blocks `javascript:`/`data:`/`file:`.
- **loopback** (`localhost`/`127.0.0.1`/`::1`/`*.localhost`) always allowed — local dev, the node, desktop-local app windows.
- the **auth-frontend's own origin** (the node) always allowed.
- additional **deployed app origins** via `VITE_ALLOWED_CALLBACK_ORIGINS` (comma-separated) — for hosted app frontends.
- everything else → **rejected**; the flow **fails closed** (tokens never redirected, user sees an error).

Applied at **both** redirect sites in `LoginView.tsx` (`handleAdminClientKeyGeneration`, `handleContextAndIdentitySelect`).

## Non-breaking
Local and desktop flows (loopback + same-origin) work with **no config**. Deployments serving apps from a different origin than the node add those origins to `VITE_ALLOWED_CALLBACK_ORIGINS`.

## How to test
\`\`\`
npm run build && npm test   # tsc + vite green; 85 tests pass (7 new)
\`\`\`
- `src/utils/__tests__/callbackUrl.test.ts`: rejects foreign origins, `javascript:`/`data:`/`file:`, look-alike hosts (`localhost.evil.example`), malformed/relative/empty; allows loopback (any port) and same-origin.

Manual: open the flow with `?callback-url=https://example.com` → login is not redirected there (error shown); with `?callback-url=http://localhost:5173` → works as before.

Ref: `security-review-pre-manual-test.md` H2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)