### PR TITLE
feat(auth): support the rc.14 first-login setup code (bootstrap secret)

### DIFF
--- a/src/components/auth/LoginView.tsx
+++ b/src/components/auth/LoginView.tsx
@@ -176,13 +176,29 @@ const LoginView: React.FC = () => {
    * Handle username/password authentication flow.
    * Exchanges credentials for a root token, then routes to permissions or install check.
    *
+   * Since core rc.14 (core#3221) a fresh node only mints its first root key
+   * when the caller presents the node's bootstrap secret ("setup code" —
+   * auto-generated into the node's config.toml and printed at startup by
+   * core#3270). The code is sourced from the form field when the user typed
+   * one, falling back to the `setup-code` URL param the desktop app passes so
+   * its first-run stays a plain username/password login. Once the first
+   * account exists the node ignores the value, so sending it is always safe.
+   *
    * @param username - Provided username
    * @param password - Provided password
+   * @param setupCode - Optional first-login setup code from the form
    */
-  const handleUsernamePasswordAuth = async (username: string, password: string) => {
+  const handleUsernamePasswordAuth = async (
+    username: string,
+    password: string,
+    setupCode?: string,
+  ) => {
     try {
       setUsernamePasswordLoading(true);
       setError(null);
+
+      const effectiveSetupCode =
+        setupCode?.trim() || getStoredUrlParam('setup-code')?.trim() || undefined;
 
       const mero = getMero();
       const tokenPayload = {
@@ -193,7 +209,8 @@ const LoginView: React.FC = () => {
         permissions: [] as string[],
         provider_data: {
           username: username,
-          password: password
+          password: password,
+          ...(effectiveSetupCode ? { bootstrap_secret: effectiveSetupCode } : {})
         }
       };
 

--- a/src/components/auth/UsernamePasswordForm.tsx
+++ b/src/components/auth/UsernamePasswordForm.tsx
@@ -14,20 +14,28 @@ import {
 import { PageShell } from '../common/PageShell';
 
 interface UsernamePasswordFormProps {
-  onSubmit: (username: string, password: string) => void;
+  onSubmit: (username: string, password: string, setupCode?: string) => void;
   onBack: () => void;
   loading?: boolean;
   error?: string | null;
 }
 
-export function UsernamePasswordForm({ 
-  onSubmit, 
-  onBack, 
-  loading = false, 
-  error = null 
+export function UsernamePasswordForm({
+  onSubmit,
+  onBack,
+  loading = false,
+  error = null
 }: UsernamePasswordFormProps) {
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
+  // First-login setup code (core#3221): a fresh node only creates its first
+  // account when the login presents the code merod printed at startup (also
+  // in the node's config.toml). Hidden by default — an existing user never
+  // needs it — but revealed on demand, and automatically after a failed
+  // sign-in, because a fresh node reports a missing code as the same
+  // "Invalid username or password" a typo produces.
+  const [setupCode, setSetupCode] = useState('');
+  const [showSetupCode, setShowSetupCode] = useState(false);
   const [validationError, setValidationError] = useState<string | null>(null);
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -50,10 +58,11 @@ export function UsernamePasswordForm({
       return;
     }
 
-    onSubmit(username.trim(), password);
+    onSubmit(username.trim(), password, setupCode.trim() || undefined);
   };
 
   const displayError = validationError || error;
+  const setupCodeVisible = showSetupCode || Boolean(error);
 
   return (
     <PageShell>
@@ -100,17 +109,58 @@ export function UsernamePasswordForm({
                 />
               </Stack>
 
+              {setupCodeVisible ? (
+                <Stack spacing="xs">
+                  <Text size="sm" weight="medium">
+                    Setup code (first login only)
+                  </Text>
+                  <Input
+                    id="setup-code"
+                    type="text"
+                    value={setupCode}
+                    onChange={(e) => setSetupCode(e.target.value)}
+                    placeholder="Code from the node's startup log"
+                    disabled={loading}
+                    autoComplete="off"
+                  />
+                  <Text size="xs" color="muted">
+                    Setting up a fresh node? Its first account can only be
+                    created with the setup code shown in the node's startup
+                    log (and stored in its config.toml). Existing accounts
+                    sign in without it.
+                  </Text>
+                </Stack>
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => setShowSetupCode(true)}
+                  disabled={loading}
+                  style={{
+                    alignSelf: 'flex-start',
+                    background: 'none',
+                    border: 'none',
+                    padding: 0,
+                    color: 'var(--color-text-muted, #9ca3af)',
+                    textDecoration: 'underline',
+                    cursor: 'pointer',
+                    fontSize: '0.85rem',
+                  }}
+                >
+                  First login on a fresh node? Enter its setup code
+                </button>
+              )}
+
               <Flex justify="flex-end" gap="sm">
-                <Button 
-                  type="button" 
+                <Button
+                  type="button"
                   variant="secondary"
-                  onClick={onBack} 
+                  onClick={onBack}
                   disabled={loading}
                 >
                   Back
                 </Button>
-                <Button 
-                  type="submit" 
+                <Button
+                  type="submit"
                   variant="primary"
                   disabled={loading || !username.trim() || !password.trim()}
                   style={{
@@ -128,4 +178,4 @@ export function UsernamePasswordForm({
       </Card>
     </PageShell>
   );
-} 
+}

--- a/src/utils/urlParams.ts
+++ b/src/utils/urlParams.ts
@@ -129,7 +129,10 @@ export const clearStoredUrlParams = () => {
     'package-name',
     'package-version',
     'registry-url',
-    'mode'
+    'mode',
+    // First-login bootstrap secret passed by the desktop app (core#3221) —
+    // it's a credential, so never leave it behind after the flow completes.
+    'setup-code'
   ];
   
   keysToRemove.forEach(key => {


### PR DESCRIPTION
## Problem

core rc.14 ([core#3221](https://github.com/calimero-network/core/issues/3221)) gates a fresh node's first root key behind an out-of-band bootstrap secret, and this form had no way to present it — so the **first login on every fresh rc.14 node fails** with the generic 401 `Invalid username or password` (deliberately indistinguishable from a typo, so users can't even tell why). Our own CI works around it by pre-minting the key with curl (0fc63c5).

Pairs with [core#3270](https://github.com/calimero-network/core/pull/3270), which auto-generates the secret into the node's config.toml and prints it at startup as a **setup code**.

## Change

- Login sends `provider_data.bootstrap_secret`, sourced from a new optional **setup code** form field, falling back to the `setup-code` URL param — the desktop app passes that param after reading the code from the node config it manages, so its first-run login stays a plain username/password (tauri-app PR follows). Omitted entirely when absent; once the first account exists the node ignores the value, so sending it is always safe.
- The field is hidden behind a *"First login on a fresh node? Enter its setup code"* link and **auto-revealed after a failed sign-in** — exactly the moment a fresh-node user hits the opaque 401.
- `setup-code` is cleared with the other flow params after the flow completes (it's a credential; it must not linger in sessionStorage).

## Verification

- `npm run build` + `npm test`: 88/88 green.
- The wire shape (`provider_data: {username, password, bootstrap_secret}`) verified against a live core#3270 debug node: bootstrap call mints the root key + returns tokens; subsequent plain logins succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)