### PR TITLE
fix(auth): wire the setup code on the app-callback flow + registry-trusted callbacks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,28 +88,19 @@ jobs:
           echo "node never became healthy" >&2
           exit 1
 
-      - name: Bootstrap root key (out-of-band secret)
-        # rc.14 disables trust-on-first-use: mint the root key here presenting
-        # MERO_AUTH_BOOTSTRAP_SECRET so the UI's dev/dev-password login is a plain
-        # existing-user auth (the UI form has no bootstrap-secret field).
-        run: |
-          BODY=$(jq -n --arg u "$MERO_E2E_USER" --arg p "$MERO_E2E_PASS" \
-            --arg s "$MERO_AUTH_BOOTSTRAP_SECRET" --argjson ts "$(date +%s)" \
-            '{auth_method: "user_password", public_key: $u,
-              client_name: "ui-e2e", permissions: ["admin"], timestamp: $ts,
-              provider_data: {username: $u, password: $p, bootstrap_secret: $s}}')
-          RESP=$(curl -fsS -m 10 -X POST http://localhost:4081/auth/token \
-            -H 'Content-Type: application/json' -d "$BODY") || {
-              echo "::error::root-key bootstrap request failed"; exit 1; }
-          echo "$RESP" | jq -e '.data.access_token // empty' > /dev/null || {
-            echo "::error::bootstrap did not return a token: $RESP"; exit 1; }
-          echo "root key bootstrapped for $MERO_E2E_USER"
-
+      # No out-of-band root-key pre-mint here, deliberately: the spec's first
+      # test performs the REAL first login through the UI, typing the setup
+      # code into the form. Pre-minting via curl hid exactly the bug class we
+      # shipped once already — a visible setup-code field whose value never
+      # reached the request.
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
 
       - name: Run browser e2e
-        run: NODE_URL=http://localhost:4081 npx playwright test
+        run: |
+          NODE_URL=http://localhost:4081 \
+          MERO_E2E_SETUP_CODE="$MERO_AUTH_BOOTSTRAP_SECRET" \
+          npx playwright test
 
       - name: Dump merod log on failure
         if: failure()

--- a/e2e/live-login.spec.ts
+++ b/e2e/live-login.spec.ts
@@ -23,9 +23,16 @@ import { test, expect } from '@playwright/test';
 
 const NODE_URL = process.env.NODE_URL || 'http://localhost:4081';
 const USERNAME = process.env.MERO_E2E_USER || 'dev';
-const PASSWORD = process.env.MERO_E2E_PASS || 'dev';
+const PASSWORD = process.env.MERO_E2E_PASS || 'dev-password';
+// First-login setup code (bootstrap secret, core#3221). On a fresh node the
+// FIRST login must present it — and since core >= rc.14 that is the only way
+// an account can ever be created through this UI, so the spec types it into
+// the form like a real user would. CI passes the same value it exports to the
+// merod process; on an already-bootstrapped node the field is simply ignored
+// by the server, keeping local re-runs green.
+const SETUP_CODE = process.env.MERO_E2E_SETUP_CODE || '';
 
-test('admin login flow delivers working tokens to the callback', async ({
+test('first login through the UI bootstraps the account and delivers working tokens', async ({
   page,
   request,
 }) => {
@@ -39,9 +46,19 @@ test('admin login flow delivers working tokens to the callback', async ({
   // Provider screen (list fetched live from the node).
   await page.getByText('Username/Password').click();
 
-  // Credential form; first login bootstraps the root key on a fresh node.
+  // Credential form. This drives the REAL first-run path: username/password
+  // plus the setup code typed into the revealed field. Regression pin for the
+  // shipped bug where the field rendered but its value was silently dropped
+  // by the app-callback consumer (EnsureAdminSession) — pre-minting the root
+  // key out-of-band in CI would hide that class of bug forever.
   await page.getByPlaceholder('Enter your username').fill(USERNAME);
   await page.getByPlaceholder('Enter your password').fill(PASSWORD);
+  if (SETUP_CODE) {
+    await page
+      .getByRole('button', { name: /first login on a fresh node/i })
+      .click();
+    await page.getByPlaceholder(/startup log/i).fill(SETUP_CODE);
+  }
   await page.getByRole('button', { name: 'Sign In' }).click();
 
   // Consent screen → mint the client key.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-react",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/components/auth/EnsureAdminSession.tsx
+++ b/src/components/auth/EnsureAdminSession.tsx
@@ -9,6 +9,7 @@ import {
 interface Provider { name: string; type: string; description?: string; configured?: boolean; config?: Record<string, unknown>; [key: string]: unknown; }
 import ProviderSelector from '../providers/ProviderSelector';
 import { UsernamePasswordForm } from './UsernamePasswordForm';
+import { getStoredUrlParam } from '../../utils/urlParams';
 import Loader from '../common/Loader';
 import { ErrorView } from '../common/ErrorView';
 
@@ -105,13 +106,28 @@ export const EnsureAdminSession: React.FC<EnsureAdminSessionProps> = ({ children
   };
 
   /**
-   * Handle username/password authentication
+   * Handle username/password authentication.
+   *
+   * Mirrors LoginView: the optional first-login setup code (bootstrap
+   * secret, core#3221) comes from the form field or the `setup-code` URL
+   * param, and is omitted entirely when absent. This is the consumer the
+   * app-callback flow (`/auth/login?callback-url=…`) renders, so dropping
+   * the third argument here silently breaks fresh-node first login even
+   * though the field is visible — it must stay in sync with the form's
+   * onSubmit signature.
    */
-  const handleUsernamePasswordAuth = async (username: string, password: string) => {
+  const handleUsernamePasswordAuth = async (
+    username: string,
+    password: string,
+    setupCode?: string,
+  ) => {
     setUsernamePasswordLoading(true);
     setError(null);
-    
+
     try {
+      const effectiveSetupCode =
+        setupCode?.trim() || getStoredUrlParam('setup-code')?.trim() || undefined;
+
       const mero = getMero();
       const tokenPayload = {
         auth_method: 'user_password' as const,
@@ -121,7 +137,8 @@ export const EnsureAdminSession: React.FC<EnsureAdminSessionProps> = ({ children
         permissions: [] as string[],
         provider_data: {
           username,
-          password
+          password,
+          ...(effectiveSetupCode ? { bootstrap_secret: effectiveSetupCode } : {})
         }
       };
 

--- a/src/components/auth/LoginView.tsx
+++ b/src/components/auth/LoginView.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useCallback, useEffect } from 'react';
 import ProviderSelector from '../providers/ProviderSelector';
 import { handleUrlParams, getStoredUrlParam } from '../../utils/urlParams';
-import { resolveSafeCallbackUrl, redirectTokensToCallback } from '../../utils/callbackUrl';
+import { resolveTrustedCallbackUrl, redirectTokensToCallback } from '../../utils/callbackUrl';
 import {
   getMero,
   generateClientKeyDirect,
@@ -295,7 +295,7 @@ const LoginView: React.FC = () => {
 
       if (response.access_token && response.refresh_token) {
         const callback = getStoredUrlParam('callback-url');
-        const outcome = redirectTokensToCallback(callback, response, {
+        const outcome = await redirectTokensToCallback(callback, response, {
           application_id: localStorage.getItem('installed-application-id'),
         });
         if (outcome !== 'ok') {
@@ -367,7 +367,7 @@ const LoginView: React.FC = () => {
         const callback = getStoredUrlParam('callback-url');
         // Capture the app id before the shared handoff clears/redirects.
         const installedAppIdForRedirect = localStorage.getItem('installed-application-id');
-        if (!resolveSafeCallbackUrl(callback)) {
+        if (!(await resolveTrustedCallbackUrl(callback))) {
           setError(
             callback
               ? 'Login callback destination is not allowed.'
@@ -376,7 +376,7 @@ const LoginView: React.FC = () => {
           return;
         }
         localStorage.removeItem('installed-application-id');
-        redirectTokensToCallback(callback, response, {
+        await redirectTokensToCallback(callback, response, {
           application_id: installedAppIdForRedirect,
         });
       } else {

--- a/src/components/auth/__tests__/setup-code.test.tsx
+++ b/src/components/auth/__tests__/setup-code.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * Contract pin: the first-login setup code (bootstrap secret, core#3221)
+ * typed into UsernamePasswordForm MUST reach POST /auth/token as
+ * provider_data.bootstrap_secret.
+ *
+ * The form is rendered by TWO consumers — LoginView and EnsureAdminSession
+ * (the app-callback flow `/auth/login?callback-url=…`). The form passes the
+ * code as a third onSubmit argument, and TypeScript happily accepts a
+ * consumer handler that only declares two parameters — which is exactly how
+ * the EnsureAdminSession flow shipped with a visible setup-code field that
+ * silently never sent the value (fresh-node first login 401'd with the code
+ * filled in). These tests drive the real consumer so that wiring can't
+ * regress compile-clean again.
+ */
+
+import React from 'react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { EnsureAdminSession } from '../EnsureAdminSession';
+import { UsernamePasswordForm } from '../UsernamePasswordForm';
+
+const generateTokens = vi.fn(async (_payload: unknown) => ({
+  data: { access_token: 'a.b.c', refresh_token: 'r.t' },
+}));
+
+vi.mock('../../../lib/mero', () => ({
+  getMero: () => ({
+    auth: {
+      getProviders: async () => ({
+        data: {
+          providers: [{ name: 'user_password', type: 'credentials' }],
+        },
+      }),
+      generateTokens: (payload: unknown) => generateTokens(payload),
+    },
+  }),
+  hasLiveSession: async () => false,
+  isAuthRevoked: () => false,
+  setTokens: vi.fn(),
+  clearTokens: vi.fn(),
+}));
+
+async function driveEnsureAdminSessionLogin(setupCode?: string) {
+  render(
+    <EnsureAdminSession>
+      <div>children</div>
+    </EnsureAdminSession>,
+  );
+
+  // Provider list → pick user_password to reach the credential form.
+  const providerButton = await screen.findByText(/user_password/i);
+  await userEvent.click(providerButton);
+
+  await userEvent.type(await screen.findByPlaceholderText(/enter your username/i), 'admin');
+  await userEvent.type(screen.getByPlaceholderText(/enter your password/i), 'calimero-pass');
+
+  if (setupCode) {
+    await userEvent.click(
+      screen.getByRole('button', { name: /first login on a fresh node/i }),
+    );
+    await userEvent.type(screen.getByPlaceholderText(/startup log/i), setupCode);
+  }
+
+  await userEvent.click(screen.getByRole('button', { name: /sign in/i }));
+  await waitFor(() => expect(generateTokens).toHaveBeenCalledTimes(1));
+  return generateTokens.mock.calls[0][0] as {
+    provider_data: Record<string, unknown>;
+  };
+}
+
+beforeEach(() => {
+  generateTokens.mockClear();
+  sessionStorage.clear();
+  localStorage.clear();
+});
+
+describe('first-login setup code wiring', () => {
+  it('EnsureAdminSession sends the typed setup code as provider_data.bootstrap_secret', async () => {
+    const payload = await driveEnsureAdminSessionLogin('a15392ac5904880da94199864f8294d2');
+    expect(payload.provider_data).toMatchObject({
+      username: 'admin',
+      password: 'calimero-pass',
+      bootstrap_secret: 'a15392ac5904880da94199864f8294d2',
+    });
+  });
+
+  it('EnsureAdminSession omits bootstrap_secret entirely when no code is given', async () => {
+    const payload = await driveEnsureAdminSessionLogin();
+    expect(payload.provider_data).toMatchObject({
+      username: 'admin',
+      password: 'calimero-pass',
+    });
+    expect(payload.provider_data).not.toHaveProperty('bootstrap_secret');
+  });
+
+  it('EnsureAdminSession falls back to the setup-code URL param (desktop flow)', async () => {
+    sessionStorage.setItem('setup-code', 'url-param-code-123');
+    const payload = await driveEnsureAdminSessionLogin();
+    expect(payload.provider_data).toMatchObject({
+      bootstrap_secret: 'url-param-code-123',
+    });
+  });
+
+  it('UsernamePasswordForm passes the setup code as the third onSubmit argument', async () => {
+    const onSubmit = vi.fn();
+    render(<UsernamePasswordForm onSubmit={onSubmit} onBack={() => {}} />);
+
+    await userEvent.type(screen.getByPlaceholderText(/enter your username/i), 'admin');
+    await userEvent.type(screen.getByPlaceholderText(/enter your password/i), 'calimero-pass');
+    await userEvent.click(
+      screen.getByRole('button', { name: /first login on a fresh node/i }),
+    );
+    await userEvent.type(screen.getByPlaceholderText(/startup log/i), 'code-42');
+    await userEvent.click(screen.getByRole('button', { name: /sign in/i }));
+
+    expect(onSubmit).toHaveBeenCalledWith('admin', 'calimero-pass', 'code-42');
+  });
+});

--- a/src/flows/AdminFlow.tsx
+++ b/src/flows/AdminFlow.tsx
@@ -36,7 +36,7 @@ export const AdminFlow: React.FC = () => {
 
       if (response.access_token && response.refresh_token) {
         const callback = getStoredUrlParam('callback-url');
-        const outcome = redirectTokensToCallback(callback, response);
+        const outcome = await redirectTokensToCallback(callback, response);
         if (outcome !== 'ok') {
           setError(
             outcome === 'missing'

--- a/src/flows/ApplicationFlow.tsx
+++ b/src/flows/ApplicationFlow.tsx
@@ -65,7 +65,7 @@ export const ApplicationFlow: React.FC<ApplicationFlowProps> = ({
 
       if (response.access_token && response.refresh_token) {
         const callback = getStoredUrlParam('callback-url');
-        const outcome = redirectTokensToCallback(callback, response, {
+        const outcome = await redirectTokensToCallback(callback, response, {
           context_id: contextId,
           context_identity: identity,
         });

--- a/src/flows/PackageFlow.tsx
+++ b/src/flows/PackageFlow.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useState } from 'react';
 import { generateClientKeyDirect } from '../lib/mero';
-import { resolveSafeCallbackUrl, redirectTokensToCallback } from '../utils/callbackUrl';
+import { resolveTrustedCallbackUrl, redirectTokensToCallback } from '../utils/callbackUrl';
 import { ManifestProcessor } from '../components/manifest/ManifestProcessor';
 import { PermissionsView } from '../components/permissions/PermissionsView';
 import { ContextSelector } from '../components/context/ContextSelector';
@@ -110,7 +110,7 @@ export const PackageFlow: React.FC<PackageFlowProps> = ({
         const callback = getStoredUrlParam('callback-url');
         // Validate the callback BEFORE the package-flow cleanup + redirect, so a
         // missing/untrusted callback hands out no tokens and leaves state intact.
-        if (!resolveSafeCallbackUrl(callback)) {
+        if (!(await resolveTrustedCallbackUrl(callback))) {
           setError(
             callback
               ? 'Login callback destination is not allowed.'
@@ -123,7 +123,7 @@ export const PackageFlow: React.FC<PackageFlowProps> = ({
         sessionStorage.removeItem('installed-application-id');
         localStorage.removeItem('installed-application-id');
         localStorage.removeItem('manifest-info');
-        redirectTokensToCallback(callback, response, {
+        await redirectTokensToCallback(callback, response, {
           application_id: installedAppId,
           context_id: contextId,
           context_identity: identity,

--- a/src/utils/__tests__/callbackUrl.test.ts
+++ b/src/utils/__tests__/callbackUrl.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { resolveSafeCallbackUrl, redirectTokensToCallback } from '../callbackUrl';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../../vitest.setup';
+import {
+  resolveSafeCallbackUrl,
+  resolveTrustedCallbackUrl,
+  redirectTokensToCallback,
+} from '../callbackUrl';
 
 describe('resolveSafeCallbackUrl', () => {
   it('rejects a missing / empty callback', () => {
@@ -75,23 +81,23 @@ describe('redirectTokensToCallback', () => {
     vi.restoreAllMocks();
   });
 
-  it('returns "missing" and does not navigate when no callback is given', () => {
+  it('returns "missing" and does not navigate when no callback is given', async () => {
     const before = window.location.href;
-    expect(redirectTokensToCallback(null, tokens)).toBe('missing');
+    expect(await redirectTokensToCallback(null, tokens)).toBe('missing');
     expect(window.location.href).toBe(before);
   });
 
-  it('returns "untrusted" and does not navigate for a foreign origin', () => {
+  it('returns "untrusted" and does not navigate for a foreign origin', async () => {
     const before = window.location.href;
-    expect(redirectTokensToCallback('https://evil.example/cb', tokens)).toBe(
+    expect(await redirectTokensToCallback('https://evil.example/cb', tokens)).toBe(
       'untrusted',
     );
     // The token pair must never reach an untrusted origin.
     expect(window.location.href).toBe(before);
   });
 
-  it('redirects the token pair in the fragment for a trusted loopback callback', () => {
-    const outcome = redirectTokensToCallback(
+  it('redirects the token pair in the fragment for a trusted loopback callback', async () => {
+    const outcome = await redirectTokensToCallback(
       'http://localhost:5173/cb',
       tokens,
       { context_id: 'CTX', context_identity: null },
@@ -107,5 +113,85 @@ describe('redirectTokensToCallback', () => {
     // null / empty extras are skipped, not serialized as "null".
     expect(params.has('context_identity')).toBe(false);
     expect(params.get('node_url')).toBeTruthy();
+  });
+});
+
+/**
+ * Registry-declared frontend trust: the standard browser flow is a HOSTED app
+ * (e.g. https://mero-chat.vercel.app) logging into a local node. The static
+ * policy alone rejected it — and the frontend is baked into merod at build
+ * time, so a build-time env allowlist can't be extended in the field. The app
+ * registry's bundle manifest declares each package's frontend URL
+ * (links.frontend); a callback matching that origin is trusted, OAuth
+ * registered-redirect-URI style. Verdicts are memoized per origin per page
+ * load, so each test uses a distinct origin.
+ */
+describe('resolveTrustedCallbackUrl (registry-declared frontends)', () => {
+  const REGISTRY = 'https://apps.calimero.network';
+
+  function serveManifest(registryOrigin: string, pkg: string, frontend?: string) {
+    server.use(
+      http.get(`${registryOrigin}/api/v2/bundles`, ({ request }) => {
+        const url = new URL(request.url);
+        if (url.searchParams.get('package') !== pkg) {
+          return HttpResponse.json([], { status: 404 });
+        }
+        return HttpResponse.json([
+          {
+            version: '1.0',
+            package: pkg,
+            appVersion: '1.2.3',
+            wasm: { hash: 'sha256:abc' },
+            links: frontend ? { frontend } : {},
+          },
+        ]);
+      }),
+    );
+  }
+
+  beforeEach(() => {
+    sessionStorage.clear();
+    localStorage.clear();
+  });
+
+  it('trusts a callback whose origin the registry declares for the flow package', async () => {
+    sessionStorage.setItem('package-name', 'com.calimero.curb');
+    serveManifest(REGISTRY, 'com.calimero.curb', 'https://mero-chat-a.vercel.app/login');
+
+    const url = await resolveTrustedCallbackUrl('https://mero-chat-a.vercel.app/login');
+    expect(url?.origin).toBe('https://mero-chat-a.vercel.app');
+  });
+
+  it('rejects a callback origin the registry does not declare', async () => {
+    sessionStorage.setItem('package-name', 'com.calimero.curb');
+    serveManifest(REGISTRY, 'com.calimero.curb', 'https://mero-chat-b.vercel.app/login');
+
+    expect(await resolveTrustedCallbackUrl('https://evil-b.example/cb')).toBeNull();
+  });
+
+  it('rejects when the flow has no package-name', async () => {
+    expect(
+      await resolveTrustedCallbackUrl('https://mero-chat-c.vercel.app/cb'),
+    ).toBeNull();
+  });
+
+  it('ignores an attacker-supplied registry-url and consults the default registry', async () => {
+    sessionStorage.setItem('package-name', 'com.calimero.curb');
+    // An attacker registry happily "declares" their exfiltration origin…
+    sessionStorage.setItem('registry-url', 'https://evil-registry.example');
+    serveManifest('https://evil-registry.example', 'com.calimero.curb', 'https://evil-d.example');
+    // …but the trusted default registry declares the real frontend.
+    serveManifest(REGISTRY, 'com.calimero.curb', 'https://mero-chat-d.vercel.app');
+
+    expect(await resolveTrustedCallbackUrl('https://evil-d.example/cb')).toBeNull();
+  });
+
+  it('fails closed when the registry lookup errors', async () => {
+    sessionStorage.setItem('package-name', 'com.calimero.broken');
+    server.use(http.get(`${REGISTRY}/api/v2/bundles`, () => HttpResponse.error()));
+
+    expect(
+      await resolveTrustedCallbackUrl('https://mero-chat-e.vercel.app/cb'),
+    ).toBeNull();
   });
 });

--- a/src/utils/callbackUrl.ts
+++ b/src/utils/callbackUrl.ts
@@ -1,5 +1,6 @@
-import { clearStoredUrlParams } from './urlParams';
+import { clearStoredUrlParams, getStoredUrlParam } from './urlParams';
 import { getAppEndpointKey } from '../lib/mero';
+import { createRegistryClient, registryClient } from './registryClient';
 
 // Allowlist validation for the SSO `callback-url`.
 //
@@ -20,6 +21,15 @@ import { getAppEndpointKey } from '../lib/mero';
 //   * any additional deployed app origins must be explicitly allowlisted via
 //     the `VITE_ALLOWED_CALLBACK_ORIGINS` build/env var (comma-separated), e.g.
 //     "https://app.example.com,https://chat.example.com"
+//   * a hosted app may also be trusted DYNAMICALLY: when the login flow names
+//     a package (`package-name` param), the app registry's bundle manifest
+//     declares that app's frontend URL (`links.frontend`) — the moral
+//     equivalent of OAuth's registered redirect URIs. A callback whose origin
+//     matches the registry-declared frontend origin is trusted. The manifest
+//     is only consulted from a TRUSTED registry (the built-in default, or a
+//     `registry-url` whose own origin passes the static policy) — otherwise
+//     an attacker could point `registry-url` at a registry that "declares"
+//     their exfiltration origin.
 //   * everything else is rejected — the caller must NOT redirect the tokens.
 
 const isLoopbackHost = (host: string): boolean => {
@@ -71,22 +81,97 @@ const allowedOrigins = (): Set<string> => {
  *   origin. On `null`, the caller MUST NOT redirect the token pair.
  */
 export function resolveSafeCallbackUrl(raw: string | null | undefined): URL | null {
-  if (!raw) return null;
-
-  let url: URL;
-  try {
-    url = new URL(raw);
-  } catch {
-    return null;
-  }
-
-  if (url.protocol !== 'http:' && url.protocol !== 'https:') return null;
+  const url = parseHttpUrl(raw);
+  if (!url) return null;
 
   if (isLoopbackHost(url.hostname)) return url;
 
   if (allowedOrigins().has(url.origin)) return url;
 
   return null;
+}
+
+const parseHttpUrl = (raw: string | null | undefined): URL | null => {
+  if (!raw) return null;
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    return null;
+  }
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') return null;
+  return url;
+};
+
+const DEFAULT_REGISTRY_ORIGIN = new URL(
+  (import.meta.env.VITE_REGISTRY_URL as string | undefined) ||
+    'https://apps.calimero.network',
+).origin;
+
+// One registry verdict per origin per page load: the pre-flight check and the
+// token handoff both consult this, and the answer cannot meaningfully change
+// between them.
+const registryVerdicts = new Map<string, Promise<boolean>>();
+
+/**
+ * True when the app registry declares `origin` as the frontend origin of the
+ * package this login flow is for. Fails closed on any error (no package in
+ * the flow, manifest missing, no frontend link, network failure).
+ */
+const isRegistryDeclaredFrontend = (origin: string): Promise<boolean> => {
+  let verdict = registryVerdicts.get(origin);
+  if (!verdict) {
+    verdict = (async () => {
+      const packageName = getStoredUrlParam('package-name');
+      if (!packageName) return false;
+
+      // Only consult a registry we already trust. The raw `registry-url`
+      // param is attacker-controllable, so it is honored only when its own
+      // origin passes the static policy (loopback / same-origin / env
+      // allowlist) or is the built-in default; anything else falls back to
+      // the default registry.
+      const rawRegistry = getStoredUrlParam('registry-url');
+      const registryUrl = parseHttpUrl(rawRegistry);
+      const registryTrusted =
+        registryUrl !== null &&
+        (registryUrl.origin === DEFAULT_REGISTRY_ORIGIN ||
+          isLoopbackHost(registryUrl.hostname) ||
+          allowedOrigins().has(registryUrl.origin));
+      const client =
+        registryTrusted && registryUrl
+          ? createRegistryClient(registryUrl.origin)
+          : registryClient;
+
+      try {
+        const manifest = await client.getManifest(packageName);
+        const frontend = parseHttpUrl(manifest._bundleLinks?.frontend);
+        return frontend !== null && frontend.origin === origin;
+      } catch (err) {
+        console.warn('Registry lookup for callback trust failed:', err);
+        return false;
+      }
+    })();
+    registryVerdicts.set(origin, verdict);
+  }
+  return verdict;
+};
+
+/**
+ * Full trust resolution for a `callback-url`: the static policy first
+ * (loopback, same-origin, env allowlist), then the registry-declared frontend
+ * origin of the flow's package. Same contract as
+ * [`resolveSafeCallbackUrl`], asynchronously.
+ */
+export async function resolveTrustedCallbackUrl(
+  raw: string | null | undefined,
+): Promise<URL | null> {
+  const staticUrl = resolveSafeCallbackUrl(raw);
+  if (staticUrl) return staticUrl;
+
+  const url = parseHttpUrl(raw);
+  if (!url) return null;
+
+  return (await isRegistryDeclaredFrontend(url.origin)) ? url : null;
 }
 
 /**
@@ -104,14 +189,14 @@ export function resolveSafeCallbackUrl(raw: string | null | undefined): URL | nu
  *   cases the tokens are NOT handed out and no navigation happens; the caller
  *   should surface an error.
  */
-export function redirectTokensToCallback(
+export async function redirectTokensToCallback(
   rawCallback: string | null | undefined,
   tokens: { access_token: string; refresh_token: string },
   extra: Record<string, string | null | undefined> = {},
-): 'ok' | 'missing' | 'untrusted' {
+): Promise<'ok' | 'missing' | 'untrusted'> {
   if (!rawCallback) return 'missing';
 
-  const returnUrl = resolveSafeCallbackUrl(rawCallback);
+  const returnUrl = await resolveTrustedCallbackUrl(rawCallback);
   if (!returnUrl) return 'untrusted';
 
   const fragmentParams = new URLSearchParams();


### PR DESCRIPTION
Two commits that landed on the #40 branch **after** it was merged this morning (v1.3.1 shipped without them) — this is the PR that actually fixes what Fran hit live:

1. **Setup-code field rendered but value silently dropped** (`e56926f`): `UsernamePasswordForm` has two consumers and only `LoginView` was wired in v1.3.1. `EnsureAdminSession` — the consumer the app-callback flow (`/auth/login?callback-url=…`) renders — declared a 2-arg onSubmit, so TS discarded the third argument compile-clean and `provider_data.bootstrap_secret` never left the browser. Fresh-node first login 401'd with the code typed correctly. + 4 component regression tests driving the real consumer.

2. **"Login callback destination is not allowed" for hosted apps** (`583fb86`): the #39 allowlist (loopback/same-origin/build-env) broke hosted-app → local-node login. Now: **registry-declared frontend trust** — the flow's package manifest `links.frontend` origin is trusted (OAuth registered-redirect-URI equivalent); `registry-url` only honored when its own origin passes the static policy; fail-closed; async handoff awaited at every call site. + 5 msw unit tests.

3. **e2e hardening**: CI no longer pre-mints the root key via curl — the live spec drives the REAL first login through the UI, typing the setup code into the form. The pre-mint is exactly what hid bug 1.

97 unit + 2 live-e2e green against a fresh rc.15 node.

⚠️ Chain: merge this → cut auth-frontend release (>v1.3.1) → merge core#3274 (rc.16 re-embeds the UI) → tauri#149 + v0.0.69.

🤖 Generated with [Claude Code](https://claude.com/claude-code)